### PR TITLE
Allow making the manifest source a HTTP/HTTPS url

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,8 @@ from yente.app import app
 
 run_id = uuid4().hex
 settings.TESTING = True
-settings.MANIFEST = Path(__file__).parent / "../fixtures/manifest.yml"
+MANIFEST_PATH = Path(__file__).parent / "../fixtures/manifest.yml"
+settings.MANIFEST = str(MANIFEST_PATH)
 settings.UPDATE_TOKEN = "test"
 settings.ES_INDEX = f"yente-test-{run_id}"
 settings.ENTITY_INDEX = f"{settings.ES_INDEX}-entities"

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 import pytest
+
 from .conftest import client
 
 from yente.data import get_datasets, get_manifest
-
+from yente.data.util import resolve_url_type
 
 @pytest.mark.asyncio
 async def test_manifest():
@@ -17,3 +19,16 @@ async def test_local_dataset():
     ds = datasets["parteispenden"]
     entities = [e async for e in ds.entities()]
     assert len(entities) > 10, entities
+
+
+def test_resolve_url_type():
+    out = resolve_url_type('http://banana.com/bla.txt')
+    assert isinstance(out, str)
+    out = resolve_url_type(__file__)
+    assert isinstance(out, Path)
+
+    with pytest.raises(RuntimeError):
+        resolve_url_type('ftp://banana.com/bla.txt')
+
+    with pytest.raises(RuntimeError):
+        resolve_url_type('/no/such/path.csv')

--- a/yente/data/util.py
+++ b/yente/data/util.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from functools import lru_cache
+from urllib.parse import urlparse
 import fingerprints
 from normality import WS
 from datetime import datetime
@@ -6,7 +8,7 @@ from Levenshtein import distance  # type: ignore
 from prefixdate.precision import Precision
 from contextlib import asynccontextmanager
 from aiohttp import ClientSession, ClientTimeout
-from typing import AsyncGenerator, Dict, List, Optional, Set, cast
+from typing import AsyncGenerator, Dict, List, Optional, Set, Union
 from followthemoney.types import registry
 
 
@@ -96,6 +98,19 @@ def pick_names(names: List[str], limit: int = 3) -> List[str]:
         picked.append(pick)
 
     return picked
+
+
+def resolve_url_type(url: str) -> Union[Path, str]:
+    """Check if a given path is local or remote and return a parsed form."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme in ('http', 'https'):
+        return url
+    if parsed.path:
+        path = Path(parsed.path).resolve()
+        if path.exists():
+            return path
+    raise RuntimeError("Cannot open resource: %s" % url)
 
 
 @asynccontextmanager

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -85,8 +85,8 @@ TAGS: List[Dict[str, Any]] = [
 TESTING = False
 DEBUG = as_bool(env_str("YENTE_DEBUG", "false"))
 
-MANIFEST = Path(__file__).parent.parent / "manifests/default.yml"
-MANIFEST = Path(env_str("YENTE_MANIFEST") or MANIFEST).resolve()
+MANIFEST_DEFAULT_PATH = Path(__file__).parent.parent / "manifests/default.yml"
+MANIFEST = env_str("YENTE_MANIFEST") or str(MANIFEST_DEFAULT_PATH)
 MANIFEST_CRONTAB = env_str("YENTE_MANIFEST_CRONTAB")
 
 CRON_UPDATE: Optional[Cron] = None


### PR DESCRIPTION
This can be enabled by setting `YENTE_MANIFEST` to a url like `https://my.intranet/yente_manifest.yml`