### PR TITLE
Revamp metadata architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ Defining these extra indexing options is handled via a YAML file you can supply 
 schedule: "*/30 * * * *"
 # Import external dataset specifications from OpenSanctions. This will fetch the dataset
 # metadata from the given index and make them available to yente.
-external:
-  # nb. replace `latest` with a date stamp (e.g. 20220419) to fetch historical
-  # OpenSanctions data for a particular day:
-  url: "https://data.opensanctions.org/datasets/latest/index.json"
-  # Limit the dataset scope of the entities which will be indexed into yente. Useful
-  # values include `default`, `sanctions` or `peps`.
-  scope: all
+catalogs:
+  - # nb. replace `latest` with a date stamp (e.g. 20220419) to fetch historical
+    # OpenSanctions data for a particular day:
+    url: "https://data.opensanctions.org/datasets/latest/index.json"
+    # Limit the dataset scope of the entities which will be indexed into yente. Useful
+    # values include `default`, `sanctions` or `peps`.
+    scope: all
+    resource_name: entities.ftm.json
 # The next section begins to specify non-OpenSanctions datasets that should be exposed
 # in the API:
 datasets:

--- a/manifests/default.yml
+++ b/manifests/default.yml
@@ -1,7 +1,8 @@
 schedule: "*/30 * * * *"
-external:
-  url: "https://data.opensanctions.org/datasets/latest/index.json"
-  scope: all
+catalogs:
+  - url: "https://data.opensanctions.org/datasets/latest/index.json"
+    scope: all
+    resource_name: entities.ftm.json
 datasets:
   []
   # - name: external_offshoreleaks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 followthemoney==3.1.0
-nomenklatura==2.6.3
+nomenklatura==2.7.3
 asyncstdlib==3.10.5
 aiocron==1.8
 aiocsv==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
-followthemoney==3.1.0
+followthemoney==3.2.0
 nomenklatura==2.7.3
 asyncstdlib==3.10.5
 aiocron==1.8
 aiocsv==1.2.3
 aiofiles==22.1.0
-types-aiofiles==22.1.0.1
+types-aiofiles==22.1.0.4
 aiohttp[speedups]==3.8.3
-elasticsearch[async]==8.5.0
-fastapi==0.86.0
-uvicorn[standard]==0.19.0
+elasticsearch[async]==8.5.2
+fastapi==0.88.0
+uvicorn[standard]==0.20.0
 python-multipart==0.0.5
 email-validator==1.3.0
 structlog==22.1.0
 pyicu==2.10.2
-orjson==3.8.1
+orjson==3.8.2
 text-unidecode==1.3
 click==8.0.4
 
@@ -21,4 +21,4 @@ normality==2.4.0
 languagecodes==1.1.1
 countrynames==1.14.1
 fingerprints==1.0.3
-pantomime==0.5.1
+pantomime==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             "wheel>=0.29.0",
             "twine",
             "mypy",
+            "httpx",
             "pytest",
             "pytest-cov",
             "pytest-asyncio",

--- a/tests/fixtures/manifest.yml
+++ b/tests/fixtures/manifest.yml
@@ -1,7 +1,8 @@
 schedule: null
-external:
-  url: "https://data.opensanctions.org/datasets/latest/index.json"
-  scope: eu_fsf
+catalogs:
+  - url: "https://data.opensanctions.org/datasets/latest/index.json"
+    scope: eu_fsf
+    resource_name: entities.ftm.json
 datasets:
   - name: parteispenden
     title: German political party donations

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -22,7 +22,7 @@ def test_manifest():
     assert res.status_code == 200, res
     data = res.json()
     assert "datasets" in data
-    assert "schedule" in data
+    assert len(data["datasets"]) > 5
 
 
 def test_updatez_get():

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -3,8 +3,9 @@ import pytest
 
 from .conftest import client
 
-from yente.data import get_datasets, get_manifest
+from yente.data import get_catalog, get_manifest
 from yente.data.util import resolve_url_type
+
 
 @pytest.mark.asyncio
 async def test_manifest():
@@ -15,20 +16,20 @@ async def test_manifest():
 
 @pytest.mark.asyncio
 async def test_local_dataset():
-    datasets = await get_datasets()
-    ds = datasets["parteispenden"]
+    catalog = await get_catalog()
+    ds = catalog.require("parteispenden")
     entities = [e async for e in ds.entities()]
     assert len(entities) > 10, entities
 
 
 def test_resolve_url_type():
-    out = resolve_url_type('http://banana.com/bla.txt')
+    out = resolve_url_type("http://banana.com/bla.txt")
     assert isinstance(out, str)
     out = resolve_url_type(__file__)
     assert isinstance(out, Path)
 
     with pytest.raises(RuntimeError):
-        resolve_url_type('ftp://banana.com/bla.txt')
+        resolve_url_type("ftp://banana.com/bla.txt")
 
     with pytest.raises(RuntimeError):
-        resolve_url_type('/no/such/path.csv')
+        resolve_url_type("/no/such/path.csv")

--- a/yente/data/__init__.py
+++ b/yente/data/__init__.py
@@ -1,9 +1,10 @@
 import structlog
 from structlog.stdlib import BoundLogger
 from asyncstdlib.functools import cache
+from nomenklatura.dataset import DataCatalog
 
 from yente.data.manifest import Manifest
-from yente.data.dataset import Dataset, Datasets
+from yente.data.dataset import Dataset
 
 log: BoundLogger = structlog.get_logger(__name__)
 
@@ -14,16 +15,15 @@ async def get_manifest() -> Manifest:
 
 
 @cache
-async def get_datasets() -> Datasets:
+async def get_catalog() -> DataCatalog[Dataset]:
     manifest = await get_manifest()
-    datasets: Datasets = {}
+    catalog = DataCatalog(Dataset, {})
     for dmf in manifest.datasets:
-        dataset = Dataset(datasets, dmf)
-        datasets[dataset.name] = dataset
-    return datasets
+        catalog.make_dataset(dmf)
+    return catalog
 
 
 async def refresh_manifest() -> None:
     log.info("Refreshing manifest metadata...")
     get_manifest.cache_clear()
-    get_datasets.cache_clear()
+    get_catalog.cache_clear()

--- a/yente/data/__init__.py
+++ b/yente/data/__init__.py
@@ -9,14 +9,13 @@ from yente.data.dataset import Dataset
 log: BoundLogger = structlog.get_logger(__name__)
 
 
-@cache
 async def get_manifest() -> Manifest:
     return await Manifest.load()
 
 
 @cache
 async def get_catalog() -> DataCatalog[Dataset]:
-    manifest = await get_manifest()
+    manifest = await Manifest.load()
     catalog = DataCatalog(Dataset, {})
     for dmf in manifest.datasets:
         catalog.make_dataset(dmf)
@@ -25,5 +24,4 @@ async def get_catalog() -> DataCatalog[Dataset]:
 
 async def refresh_manifest() -> None:
     log.info("Refreshing manifest metadata...")
-    get_manifest.cache_clear()
     get_catalog.cache_clear()

--- a/yente/data/common.py
+++ b/yente/data/common.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 from pydantic import BaseModel, Field
 from nomenklatura.matching.types import FeatureDocs
 from nomenklatura.matching.types import MatchingResult
@@ -121,3 +121,18 @@ class EntityMatchResponse(BaseModel):
     responses: Dict[str, EntityMatches]
     matcher: FeatureDocs
     limit: int = Field(..., example=5)
+
+
+class DatasetModel(BaseModel):
+    name: str
+    title: str
+    summary: Optional[str]
+    url: Optional[str]
+    load: bool
+    entities_url: Optional[str]
+    version: str
+    children: List[str]
+
+
+class DataCatalogModel(BaseModel):
+    datasets: List[DatasetModel]

--- a/yente/data/dataset.py
+++ b/yente/data/dataset.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, FileUrl, parse_obj_as, validator
 from functools import cached_property
 from typing import AsyncGenerator, Dict, List, Optional, Set
 from nomenklatura.dataset import Dataset as NomenklaturaDataset
+from nomenklatura.dataset import DataCatalog
 from followthemoney import model
 from followthemoney.namespace import Namespace
 
@@ -37,8 +38,8 @@ class DatasetManifest(BaseModel):
 
 
 class Dataset(NomenklaturaDataset):
-    def __init__(self, index: "Datasets", manifest: DatasetManifest):
-        super().__init__(name=manifest.name, title=manifest.title)
+    def __init__(self, catalog: DataCatalog, manifest: DatasetManifest):
+        super().__init__({"name": manifest.name, "title": manifest.title})
         self.index = index
         self.manifest = manifest
         self.version = manifest.version
@@ -80,9 +81,6 @@ class Dataset(NomenklaturaDataset):
             if self.ns is not None:
                 entity = self.ns.apply(entity)
             yield entity
-        
+
         if not keep_data:
             data_path.unlink(missing_ok=True)
-
-
-Datasets = Dict[str, Dataset]

--- a/yente/data/loader.py
+++ b/yente/data/loader.py
@@ -2,34 +2,32 @@ import yaml
 import orjson
 import aiofiles
 from pathlib import Path
-from pydantic import AnyHttpUrl, FileUrl
-from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Dict, Tuple, Union
+from urllib.parse import urlparse
+from typing import Any, AsyncGenerator, Tuple, Union
 
 from yente import settings
 from yente.logs import get_logger
 from yente.data.util import http_session, resolve_url_type
 
-ENCODING = "utf-"
-URL = Union[AnyHttpUrl, FileUrl]
 BUFFER = 10 * 1024 * 1024
 
 log = get_logger(__name__)
 
 
-async def get_url_path(url: URL, base_name: str) -> Tuple[Path, bool]:
-    if isinstance(url, FileUrl):
-        if url.path is None:
+async def get_url_path(url: str, base_name: str) -> Path:
+    parsed = urlparse(url)
+    if parsed.scheme.lower() == "file":
+        if parsed.path is None:
             raise ValueError("Invalid path: %s" % url)
-        return Path(url.path).resolve(), True
+        return Path(parsed.path).resolve()
     out_path = settings.DATA_PATH.joinpath(base_name)
     async with http_session() as client:
         log.info("Fetching data", url=url, path=out_path.as_posix())
-        async with client.get(str(url)) as resp:
+        async with client.get(url) as resp:
             async with aiofiles.open(out_path, "wb") as outfh:
                 while chunk := await resp.content.read(BUFFER):
                     await outfh.write(chunk)
-    return out_path, True
+    return out_path
 
 
 async def load_yaml_url(url: str) -> Any:

--- a/yente/data/util.py
+++ b/yente/data/util.py
@@ -1,25 +1,14 @@
+import fingerprints
 from pathlib import Path
 from functools import lru_cache
 from urllib.parse import urlparse
-import fingerprints
 from normality import WS
-from datetime import datetime
 from Levenshtein import distance
 from prefixdate.precision import Precision
 from contextlib import asynccontextmanager
 from aiohttp import ClientSession, ClientTimeout
 from typing import AsyncGenerator, Dict, List, Optional, Set, Union
 from followthemoney.types import registry
-
-
-def iso_datetime(value: str) -> datetime:
-    """Parse a second-precision ISO date time string."""
-    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
-
-
-def iso_to_version(value: str) -> str:
-    dt = iso_datetime(value)
-    return dt.strftime("%Y%m%d%H%M%S")
 
 
 def expand_dates(dates: List[str]) -> List[str]:

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -5,8 +5,9 @@ from starlette.responses import FileResponse
 
 from yente import settings
 from yente.logs import get_logger
-from yente.data import get_manifest, refresh_manifest
+from yente.data import get_catalog, get_manifest, refresh_manifest
 from yente.data.common import ErrorResponse, StatusResponse
+from yente.data.common import DataCatalogModel
 from yente.data.manifest import Manifest
 from yente.search.search import get_index_status
 from yente.search.indexer import update_index, update_index_threaded
@@ -71,18 +72,24 @@ async def readyz() -> StatusResponse:
 
 
 @router.get(
-    "/manifest",
-    summary="Dataset manifest",
+    "/catalog",
+    summary="Data catalog",
     tags=["Data access"],
-    response_model=Manifest,
+    response_model=DataCatalogModel,
 )
-async def manifest() -> Manifest:
+@router.get(
+    "/manifest",
+    response_model=DataCatalogModel,
+    include_in_schema=False,
+)
+async def catalog() -> DataCatalogModel:
     """Return the service manifest, which includes a list of all indexed datasets.
 
     The manifest is the configuration file of the yente service. It specifies what
     data sources are included, and how often they should be loaded.
     """
-    return await get_manifest()
+    catalog = await get_catalog()
+    return DataCatalogModel.parse_obj(catalog.to_dict())
 
 
 @router.post(

--- a/yente/routers/search.py
+++ b/yente/routers/search.py
@@ -16,7 +16,7 @@ from yente.search.queries import FilterDict
 from yente.search.search import get_entity, search_entities
 from yente.search.search import result_entities, result_facets, result_total
 from yente.search.nested import serialize_entity
-from yente.data import get_datasets
+from yente.data import get_catalog
 from yente.data.entity import Entity
 from yente.util import limit_window, EntityRedirect
 from yente.scoring import score_results
@@ -67,7 +67,7 @@ async def search(
     """
     limit, offset = limit_window(limit, offset, 10)
     ds = await get_dataset(dataset)
-    all_datasets = await get_datasets()
+    catalog = await get_catalog()
     schema_obj = model.get(schema)
     if schema_obj is None:
         raise HTTPException(400, detail="Invalid schema")
@@ -92,7 +92,7 @@ async def search(
         results.append(await serialize_entity(result))
     output = SearchResponse(
         results=results,
-        facets=result_facets(resp, all_datasets),
+        facets=result_facets(resp, catalog),
         total=result_total(resp),
         limit=limit,
         offset=offset,

--- a/yente/routers/util.py
+++ b/yente/routers/util.py
@@ -2,7 +2,7 @@ from fastapi import Path, Query
 from fastapi import HTTPException
 
 from yente.data.dataset import Dataset
-from yente.data import get_datasets
+from yente.data import get_catalog
 
 
 PATH_DATASET = Path(
@@ -14,8 +14,8 @@ QUERY_PREFIX = Query("", min_length=1, description="Search prefix")
 
 
 async def get_dataset(name: str) -> Dataset:
-    datasets = await get_datasets()
-    dataset = datasets.get(name)
+    catalog = await get_catalog()
+    dataset = catalog.get(name)
     if dataset is None:
         raise HTTPException(404, detail="No such dataset.")
     return dataset

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -41,21 +41,14 @@ async def entity_docs(
         yield {"_index": index, "_id": entity_id, "_source": data}
 
 
-def make_version(version: Optional[str]) -> str:
-    full_version = settings.INDEX_VERSION
-    if version is not None:
-        full_version = f"{full_version}{version}"
-    return full_version
-
-
 async def index_entities(es: AsyncElasticsearch, dataset: Dataset, force: bool) -> None:
     """Index entities in a particular dataset, with versioning of the index."""
     # Versioning defaults to the software version instead of a data update date:
-    version = make_version(dataset.version)
+    version = f"{settings.INDEX_VERSION}{dataset.version}"
     log.info(
         "Indexing entities",
         name=dataset.name,
-        url=dataset.manifest.url,
+        url=dataset.entities_url,
         version=version,
     )
     dataset_prefix = f"{settings.ENTITY_INDEX}-{dataset.name}"
@@ -117,7 +110,7 @@ async def update_index(force: bool = False) -> None:
         log.info("Index update check")
         indexers = []
         for dataset in catalog.datasets:
-            if dataset.is_loadable:
+            if dataset.load:
                 indexers.append(index_entities(es, dataset, force))
         await asyncio.gather(*indexers)
         log.info("Index update complete.")

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -12,7 +12,7 @@ from followthemoney.types.name import NameType
 from yente import settings
 from yente.logs import get_logger
 from yente.data.dataset import Dataset
-from yente.data import refresh_manifest, get_datasets, get_manifest
+from yente.data import refresh_manifest, get_catalog
 from yente.search.base import get_es, close_es
 from yente.search.mapping import make_entity_mapping
 from yente.search.mapping import INDEX_SETTINGS
@@ -113,11 +113,10 @@ async def update_index(force: bool = False) -> None:
     es = es_.options(request_timeout=300)
     try:
         await refresh_manifest()
-        manifest = await get_manifest()
-        datasets = await get_datasets()
+        catalog = await get_catalog()
         log.info("Index update check")
         indexers = []
-        for dataset in datasets.values():
+        for dataset in catalog.datasets:
             if dataset.is_loadable:
                 indexers.append(index_entities(es, dataset, force))
         await asyncio.gather(*indexers)

--- a/yente/search/search.py
+++ b/yente/search/search.py
@@ -8,10 +8,11 @@ from fastapi import HTTPException
 from followthemoney import model
 from followthemoney.schema import Schema
 from followthemoney.types import registry
+from nomenklatura.dataset import DataCatalog
 
 from yente import settings
 from yente.logs import get_logger
-from yente.data.dataset import Dataset, Datasets
+from yente.data.dataset import Dataset
 from yente.data.entity import Entity
 from yente.data.common import SearchFacet, SearchFacetItem, TotalSpec
 from yente.search.base import get_es, get_opaque_id, semaphore
@@ -42,7 +43,7 @@ def result_entities(response: ObjectApiResponse[Any]) -> Generator[Entity, None,
 
 
 def result_facets(
-    response: ObjectApiResponse[Any], datasets: Datasets
+    response: ObjectApiResponse[Any], catalog: DataCatalog[Dataset]
 ) -> Dict[str, SearchFacet]:
     facets: Dict[str, SearchFacet] = {}
     aggs: Dict[str, Dict[str, Any]] = response.get("aggregations", {})
@@ -57,7 +58,7 @@ def result_facets(
             if field == "datasets":
                 facet.label = "Data sources"
                 try:
-                    value.label = datasets[key].title
+                    value.label = catalog.require(key).title
                 except KeyError:
                     value.label = key
             if field in registry.groups:


### PR DESCRIPTION
This PR will adopt a new metadata data model from the upstream `nomenklatura` package. The idea is to support the use of data catalogs other than OpenSanctions with `yente`, i.e. a mechanism to have a bunch of datasets with metadata and to index them whenever there's a new version of any of the datasets. 