### PR TITLE
Supporting OpenSearch & ElasticSearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   index:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
+    image: opensearchproject/opensearch
     expose:
       - "9200"
     ports:
@@ -12,7 +12,8 @@ services:
       - cluster.name=opensanctions-index
       - discovery.type=single-node
       - bootstrap.memory_lock=true
-      - xpack.security.enabled=false
+      - plugins.security.disabled=true
+      - plugins.security.ssl.http.enabled=false
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     ulimits:
       memlock:
@@ -25,11 +26,19 @@ services:
         max_replicas_per_node: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: ['CMD', 'bash', '-ec', 'curl -u admin:admin http://localhost:9200/_cluster/health | grep -E "yellow|green"']
+      interval: 20s
+      timeout: 10s
+      start_period: 15s
+      retries: 3
 
   app:
+    container_name: yente
     image: ghcr.io/opensanctions/yente:latest
     depends_on:
-      - index
+      index:
+        condition: service_healthy
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -38,7 +47,7 @@ services:
       # Set this to a randomly generated string to enable the /updatez API:
       YENTE_UPDATE_TOKEN: ""
     # If you want to index data from the host machine as a custom dataset,
-    # create a volume mount here to make that data accessible from the 
+    # create a volume mount here to make that data accessible from the
     # container:
     # volumes:
     #   - "/path/on/the/host/computer:/data"
@@ -54,9 +63,7 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-        delay: 10s
         max_attempts: 3
-        window: 120s
 
 volumes:
   index-os-data: null

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "types-aiofiles>=23.1.0.4,<23.3",
         "aiohttp[speedups]==3.8.6",
         "elasticsearch[async]==8.10.0",
+        "opensearch-py[async]",
         "fastapi==0.103.2",
         "uvicorn[standard]==0.23.2",
         "python-multipart==0.0.6",

--- a/yente/app.py
+++ b/yente/app.py
@@ -1,6 +1,6 @@
 import time
 from uuid import uuid4
-from elasticsearch import ApiError, TransportError
+from opensearchpy import OpenSearchException, TransportError
 from fastapi import FastAPI
 from fastapi import Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -49,14 +49,14 @@ async def request_middleware(
     return response
 
 
-async def api_error_handler(request: Request, exc: ApiError) -> Response:
-    log.error(f"Search error {exc.status_code}: {exc.message}")
-    return JSONResponse(status_code=exc.status_code, content={"detail": exc.message})
+async def api_error_handler(request: Request, exc: OpenSearchException) -> Response:
+    log.error(f"Search error {exc.status_code}: {exc.error}")
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.error})
 
 
 async def transport_error_handler(request: Request, exc: TransportError) -> Response:
-    log.error(f"Transport: {exc.message}")
-    return JSONResponse(status_code=500, content={"detail": exc.message})
+    log.error(f"Transport: {exc.error}")
+    return JSONResponse(status_code=500, content={"detail": exc.error})
 
 
 def create_app() -> FastAPI:
@@ -81,6 +81,6 @@ def create_app() -> FastAPI:
     app.include_router(reconcile.router)
     app.include_router(admin.router)
 
-    app.add_exception_handler(ApiError, api_error_handler)
+    app.add_exception_handler(OpenSearchException, api_error_handler)
     app.add_exception_handler(TransportError, transport_error_handler)
     return app

--- a/yente/search/nested.py
+++ b/yente/search/nested.py
@@ -1,7 +1,7 @@
 import json
 from fastapi import HTTPException
 from typing import Dict, List, Set, Tuple, Union, Optional
-from elasticsearch import ApiError
+from opensearchpy import OpenSearchException
 from followthemoney.property import Property
 from followthemoney.types import registry
 
@@ -68,7 +68,7 @@ async def serialize_entity(root: Entity, nested: bool = False) -> EntityResponse
     next_entities = set(root.get_type_values(registry.entity))
 
     es = await get_es()
-    es_ = es.options(opaque_id=get_opaque_id())
+    es_ = es
     while True:
         shoulds = []
         if len(reverse):
@@ -94,9 +94,9 @@ async def serialize_entity(root: Entity, nested: bool = False) -> EntityResponse
                     query=query,
                     size=settings.MAX_RESULTS,
                 )
-        except ApiError as ae:
+        except OpenSearchException as ae:
             log.error(
-                f"Nested search error {ae.status_code}: {ae.message}",
+                f"Nested search error {ae.status_code}: {ae.error}",
                 index=settings.ENTITY_INDEX,
                 query_json=json.dumps(query),
             )


### PR DESCRIPTION
o/. I just wanted to run this by you before we push any further with it.

Background: we run AWS and we prefer to use managed services as much as possible. As you know, ElasticSearch is not available as an AWS managed service anymore and they offer OpenSearch. So we were wondering if we could get the basic functionality working with OpenSearch and the result is the commit that comes with this PR.

However, obviously, I understand that you would not want to move away from ElasticSearch in your own infrastructure. Hence, I would like to discuss the possibility of supporting both engines in the code. That way, we do not have to fork the code and maintain it ourselves.

After sorting out OpenSearch, we want to help with or implement incremental scans.

rel: #113 