### PR TITLE
Add schema facet and option to specify which facets are included in the response

### DIFF
--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -138,11 +138,31 @@ def test_search_facet_schema():
     addresses = res.json()["total"]["value"]
     assert addresses > 0, addresses
 
-    res = client.get("/search/default")
+    res = client.get("/search/default?facets=schema")
     assert res.status_code == 200, res
     schemata = res.json()["facets"]["schema"]
     names = [c["name"] for c in schemata["values"]]
     assert "Address" in names, names
+
+
+def test_search_facet_parameter():
+    res = client.get("/search/default")
+    assert res.status_code == 200, res
+    facets = res.json()["facets"]
+    assert len(list(facets.keys())) == 3
+    assert "schema" not in facets
+    assert "topics" in facets
+    assert "datasets" in facets
+    assert "countries" in facets
+
+    res = client.get("/search/default?facets=schema&facets=topics")
+    assert res.status_code == 200, res
+    facets = res.json()["facets"]
+    assert len(list(facets.keys())) == 2
+    assert "schema" in facets
+    assert "topics" in facets
+    assert "datasets" not in facets
+    assert "countries" not in facets
 
 
 def test_search_no_targets():

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -132,6 +132,19 @@ def test_search_facet_topics():
     assert "sanction" in names, names
 
 
+def test_search_facet_schema():
+    res = client.get("/search/default?schema=Person")
+    assert res.status_code == 200, res
+    persons = res.json()["total"]["value"]
+    assert persons > 0, persons
+
+    res = client.get("/search/default")
+    assert res.status_code == 200, res
+    schemata = res.json()["facets"]["schema"]
+    names = [c["name"] for c in schemata["values"]]
+    assert "Address" in names, names
+
+
 def test_search_no_targets():
     res = client.get("/search/default?schema=LegalEntity&target=false")
     assert res.status_code == 200, res

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -133,10 +133,10 @@ def test_search_facet_topics():
 
 
 def test_search_facet_schema():
-    res = client.get("/search/default?schema=Person")
+    res = client.get("/search/default?schema=Address")
     assert res.status_code == 200, res
-    persons = res.json()["total"]["value"]
-    assert persons > 0, persons
+    addresses = res.json()["total"]["value"]
+    assert addresses > 0, addresses
 
     res = client.get("/search/default")
     assert res.status_code == 200, res

--- a/yente/routers/search.py
+++ b/yente/routers/search.py
@@ -95,7 +95,8 @@ async def search(
         exclude_dataset=exclude_dataset,
         changed_since=changed_since,
     )
-    aggregations = facet_aggregations([f for f in filters.keys()])
+    aggregation_fields = list(filters.keys()) + ["schema"]
+    aggregations = facet_aggregations(aggregation_fields)
     resp = await search_entities(
         query,
         limit=limit,


### PR DESCRIPTION
Because filter fields are queried differently from schema.

An alternative might be to have a schemata filter, where you can filter by one or more explicit schemata, rather than the current schema parameter which does the matchable descendents cleverness. 