### PR TITLE
Use proxy in async client based on env var

### DIFF
--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 from yente.data import get_catalog
 from yente.data.loader import load_json_lines
-from yente.data.util import get_url_local_path
-from yente.data.util import phonetic_names
+from yente.data.util import get_url_local_path, phonetic_names, _proxy_env
 
 
 @pytest.mark.asyncio
@@ -56,3 +55,16 @@ def test_phonetic_names():
     assert len(phonemes) == 3
     phonemes = phonetic_names(["OAO Gazprom"])
     assert len(phonemes) == 1
+
+def test__proxy_env(monkeypatch):
+    monkeypatch.delenv("HTTP_PROXY")
+    monkeypatch.delenv("HTTPS_PROXY")
+    monkeypatch.delenv("ALL_PROXY")
+    assert _proxy_env() is None
+    proxy="http://thingy.proxy"
+    monkeypatch.setenv("ALL_PROXY", proxy)
+    assert _proxy_env() == proxy
+    monkeypatch.setenv("HTTPS_PROXY", proxy + "1")
+    assert _proxy_env() == proxy + "1"
+    monkeypatch.setenv("HTTP_PROXY", proxy + "2")
+    assert _proxy_env() == proxy + "2"

--- a/yente/data/util.py
+++ b/yente/data/util.py
@@ -1,4 +1,5 @@
 import httpx
+import os
 from pathlib import Path
 from normality import WS
 from urllib.parse import urlparse
@@ -25,6 +26,13 @@ def _clean_phonetic(original: str) -> Optional[str]:
     if not is_modern_alphabet(original):
         return None
     return fingerprint_name(original)
+
+
+def _proxy_env():
+    """Retrieve proxy from env vars if set."""
+    return os.environ.get(
+        "HTTP_PROXY", os.environ.get("HTTPS_PROXY", os.environ.get("ALL_PROXY"))
+    )
 
 
 def expand_dates(dates: List[str]) -> List[str]:
@@ -131,6 +139,6 @@ def get_url_local_path(url: str) -> Optional[Path]:
 async def httpx_session() -> AsyncGenerator[httpx.AsyncClient, None]:
     transport = httpx.AsyncHTTPTransport(retries=3)
     async with httpx.AsyncClient(
-        transport=transport, http2=True, timeout=None
+        transport=transport, http2=True, timeout=None, proxy=_proxy_env
     ) as client:
         yield client


### PR DESCRIPTION
Attempt to set proxy based on proxy env vars.
I figured I give this a try. 
I did run black. but pytest didn't work for me, probably some async specific thing. 
Fix #419