### PR TITLE
Retry full on errors

### DIFF
--- a/yente/provider/base.py
+++ b/yente/provider/base.py
@@ -60,8 +60,6 @@ class SearchProvider(object):
         """Search for entities in the index."""
         raise NotImplementedError
 
-    async def bulk_index(
-        self, entities: AsyncIterator[Dict[str, Any]]
-    ) -> Tuple[int, int]:
+    async def bulk_index(self, entities: AsyncIterator[Dict[str, Any]]) -> int:
         """Index a list of entities into the search index."""
         raise NotImplementedError

--- a/yente/provider/base.py
+++ b/yente/provider/base.py
@@ -1,5 +1,5 @@
 from asyncio import Semaphore
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from typing import AsyncIterator
 
 from yente import settings
@@ -60,6 +60,8 @@ class SearchProvider(object):
         """Search for entities in the index."""
         raise NotImplementedError
 
-    async def bulk_index(self, entities: AsyncIterator[Dict[str, Any]]) -> None:
+    async def bulk_index(
+        self, entities: AsyncIterator[Dict[str, Any]]
+    ) -> Tuple[int, int]:
         """Index a list of entities into the search index."""
         raise NotImplementedError

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -229,28 +229,23 @@ class ElasticSearchProvider(SearchProvider):
             )
             raise YenteIndexError(f"Could not search index: {ae}") from ae
 
-    async def bulk_index(
-        self, entities: AsyncIterator[Dict[str, Any]]
-    ) -> Tuple[int, int]:
+    async def bulk_index(self, entities: AsyncIterator[Dict[str, Any]]) -> int:
         """Index a list of entities into the search index.
 
         Args:
             entities: An async iterator of entities to index.
 
         Returns:
-            A tuple of the number of entities indexed and the number of errors.
+            he number of entities indexed
         """
         try:
-            n, errors = await async_bulk(
+            n, _ = await async_bulk(
                 self.client(),
                 entities,
                 chunk_size=1000,
                 raise_on_error=False,
             )
-            errors = cast(List[Any], errors)
-            for error in errors:
-                log.error("Bulk index error", error=error)
-            return n, len(errors)
+            return n
 
         except BulkIndexError as exc:
             raise YenteIndexError(f"Could not index entities: {exc}") from exc

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 import warnings
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast, Tuple
 from typing import AsyncIterator
 from elasticsearch import AsyncElasticsearch, ElasticsearchWarning
 from elasticsearch.helpers import async_bulk, BulkIndexError
@@ -229,15 +229,28 @@ class ElasticSearchProvider(SearchProvider):
             )
             raise YenteIndexError(f"Could not search index: {ae}") from ae
 
-    async def bulk_index(self, entities: AsyncIterator[Dict[str, Any]]) -> None:
-        """Index a list of entities into the search index."""
+    async def bulk_index(
+        self, entities: AsyncIterator[Dict[str, Any]]
+    ) -> Tuple[int, int]:
+        """Index a list of entities into the search index.
+
+        Args:
+            entities: An async iterator of entities to index.
+
+        Returns:
+            A tuple of the number of entities indexed and the number of errors.
+        """
         try:
-            await async_bulk(
+            n, errors = await async_bulk(
                 self.client(),
                 entities,
                 chunk_size=1000,
-                yield_ok=False,
-                stats_only=True,
+                raise_on_error=False,
             )
+            errors = cast(List[Any], errors)
+            for error in errors:
+                log.error("Bulk index error", error=error)
+            return n, len(errors)
+
         except BulkIndexError as exc:
             raise YenteIndexError(f"Could not index entities: {exc}") from exc

--- a/yente/provider/opensearch.py
+++ b/yente/provider/opensearch.py
@@ -219,22 +219,16 @@ class OpenSearchProvider(SearchProvider):
             )
             raise YenteIndexError(f"Could not search index: {ae}") from ae
 
-    async def bulk_index(
-        self, entities: AsyncIterator[Dict[str, Any]]
-    ) -> Tuple[int, int]:
+    async def bulk_index(self, entities: AsyncIterator[Dict[str, Any]]) -> int:
         """Index a list of entities into the search index."""
         try:
-            n, errors = await async_bulk(
+            n, _ = await async_bulk(
                 self.client,
                 entities,
                 chunk_size=1000,
                 max_retries=3,
                 initial_backoff=2,
-                raise_on_error=False,
             )
-            errors = cast(List[Any], errors)
-            for error in errors:
-                log.error("Bulk index error", error=error)
-            return n, len(errors)
+            return n
         except BulkIndexError as exc:
             raise YenteIndexError(f"Could not index entities: {exc}") from exc

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -141,7 +141,7 @@ async def index_entities(
         await provider.create_index(next_index)
     try:
         docs = iter_entity_docs(updater, next_index)
-        n_changed, _ = await provider.bulk_index(docs)
+        n_changed = await provider.bulk_index(docs)
     except (
         YenteIndexError,
         KeyboardInterrupt,
@@ -155,6 +155,11 @@ async def index_entities(
             log.warn("Deleting partial index", index=next_index)
             await provider.delete_index(next_index)
         if not force:
+            log.exception(
+                "Delta indexing error, retrying with full re-index: %r" % exc,
+                dataset=dataset.name,
+                index=next_index,
+            )
             return await index_entities(provider, dataset, force=True)
         raise exc
 


### PR DESCRIPTION
Here's a suggestion for how to deal with the error reporting.
We should:
- Always retry on errors ( this was supposed to already have been in place, so not getting it out the first time around was a mistake )
- When individual documents in a bulk op fails we should log the error, not raise an exception. The update is still seen as successful. 

Not sure if we want to be stricter on the individual docs failing?