### PR TITLE
Allow passing custom HOST through an env var.

### DIFF
--- a/yente/cli.py
+++ b/yente/cli.py
@@ -23,7 +23,7 @@ def serve() -> None:
     server = Server(
         Config(
             app,
-            host="0.0.0.0",
+            host=settings.HOST,
             port=settings.PORT,
             proxy_headers=True,
             reload=settings.DEBUG,

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -125,6 +125,7 @@ RESOURCES_PATH = Path(__file__).parent.joinpath("resources")
 
 BASE_SCHEMA = "Thing"
 PORT = int(env_str("YENTE_PORT", env_str("PORT", "8000")))
+HOST = int(env_str("YENTE_HOST", env_str("HOST", "0.0.0.0")))
 UPDATE_TOKEN = env_str("YENTE_UPDATE_TOKEN", "unsafe-default")
 CACHE_HEADERS = {
     "Cache-Control": "public; max-age=3600",


### PR DESCRIPTION
Currently the sever is hardcoded to listen at IPv4 only (0.0.0.0); this is a problem when running on certain infrastructure such as Fly.io, where the default private network is IPv6-only. By allowing users to pass a custom HOST, they can pass "::" to use IPv6.