### PR TITLE
Dockerfile: Use multi-stage build and base it on slim python image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,43 @@
-FROM ubuntu:24.04
-ENV DEBIAN_FRONTEND=noninteractive
+# Define the base image to use for both stages
+ARG python_image=python:3.12-slim
+
+# ------------------------------------------------------------------------
+# Stage 1: Build and install dependencies
+# ------------------------------------------------------------------------
+FROM ${python_image} AS build
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    libicu-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install python package dependencies
+ENV PATH="/opt/venv/bin:$PATH"
+COPY . /app
+RUN python -m venv /opt/venv
+RUN pip install --no-cache-dir -e /app
+
+# ------------------------------------------------------------------------
+# Stage 2: Export a final runtime image
+# ------------------------------------------------------------------------
+FROM ${python_image}
 
 LABEL org.opencontainers.image.title="OpenSanctions yente"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/opensanctions/yente"
 
-RUN apt-get -qq -y update \
-    && apt-get -y upgrade \
-    && apt-get -y install locales ca-certificates tzdata curl python3-pip \
-    python3-icu python3-cryptography python3-venv libicu-dev pkg-config \
-    libleveldb-dev libleveldb1d \
-    && apt-get -qq -y autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Set environment variables
+ENV LANG="en_US.UTF-8"
+ENV TZ="UTC"
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-    && ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-    && dpkg-reconfigure -f noninteractive tzdata \
-    && groupadd -g 10000 -r app \
-    && useradd -m -u 10000 -s /bin/false -g app app
-
-ENV LANG="en_US.UTF-8" \
-    TZ="UTC"
-
-RUN python3 -m venv /venv
-ENV PATH="/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-RUN /venv/bin/pip install --no-cache-dir --upgrade poetry
-RUN mkdir -p /app
 WORKDIR /app
-COPY . /app
-RUN pip install --no-cache-dir -e /app
+COPY --from=build /opt/venv /opt/venv
+COPY --from=build /app /app
 
-USER app:app
 CMD ["yente", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ENV PYTHONUNBUFFERED=1
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN useradd -u 10000 -s /bin/false app
+USER app
+
 WORKDIR /app
 COPY --from=build /opt/venv /opt/venv
 COPY --from=build /app /app


### PR DESCRIPTION
This Pull Request updates Dockerfile with the following changes:
1) Split it to use a multi-stage build, so the result image contain the bare minimum for running the application (Python interpreter and virtualenv with packages installed)
2) Switch to the smaller image `python:3.12-slim` (based on `debian:bookworm-slim`) to reduce the image size and reduce the attack surface.

## Effect:
### Image size:
  - Before: 1.23 GiB
  - After: 712 MiB

### Vulnerabilities:
  - Before: 803
  - After: 41
_(* Analyzed by GCP Container Analysis API)_