### PR TITLE
Install curl as runtime dependency for docker compose healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,11 @@ ENV PYTHONUNBUFFERED=1
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+# Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     libicu72 \
     ca-certificates \
+    curl # for health checks \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Docker compose doesn't have a built-in HTTP client for health checks so we make curl available in the image to perform a health check.

We still reference curl in the sample docker-compose.yml but it isn't available by default in the slim base image we recently switched to.

Fixes #692

An alternative is to change the health check to use httpx as command line client. I didn't do that because I think the attack surface or image size added by installing curl is small, while I have more confidence in `curl -f`'s behaviour remaining consistent than `httpx`.

That said, httpx does seem to exit non-zero when we want it to:

```
(jdb)-(12:33 pm Thu Mar 20)-(~/projects/opensanctions/yente):
 (692-curl-healthcheck) $ httpx http://localhost/healthz
ConnectError: [Errno 61] Connection refused
--->(1)

(jdb)-(12:34 pm Thu Mar 20)-(~/projects/opensanctions/yente):
 (692-curl-healthcheck) $ httpx http://localhost:8000/healthz
HTTP/1.1 200 OK
date: Thu, 20 Mar 2025 12:34:35 GMT
content-type: application/json
{
    "status": "ok"
}

(jdb)-(12:34 pm Thu Mar 20)-(~/projects/opensanctions/yente):
 (692-curl-healthcheck) $ httpx http://localhost:8000/health
HTTP/1.1 404 Not Found
date: Thu, 20 Mar 2025 12:34:38 GMT

{
    "detail": "Not Found"
}
--->(1)
```
