### PR TITLE
Restore old behavor of match API where topics are OR'd

### DIFF
--- a/yente/routers/match.py
+++ b/yente/routers/match.py
@@ -8,7 +8,7 @@ from yente.data.common import ErrorResponse
 from yente.data.common import EntityMatchQuery, EntityMatchResponse, EntityExample
 from yente.data.common import EntityMatches, TotalSpec
 from yente.provider import SearchProvider, get_provider
-from yente.search.queries import entity_query, FilterDict
+from yente.search.queries import entity_query, FilterDict, Operator
 from yente.search.search import search_entities, result_entities
 from yente.data.entity import Entity
 from yente.util import limit_window
@@ -58,7 +58,7 @@ async def match(
         [], title="Remove the given datasets from results"
     ),
     topics: List[str] = Query(
-        [], title="Only return results that match the given topics"
+        [], title="Only return results that match any of the given topics"
     ),
     changed_since: Optional[str] = Query(
         None,
@@ -144,6 +144,7 @@ async def match(
                 ds,
                 entity,
                 filters=filters,
+                filter_op=Operator.OR,
                 include_dataset=include_dataset,
                 exclude_schema=exclude_schema,
                 exclude_dataset=exclude_dataset,

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -115,6 +115,7 @@ def entity_query(
     exclude_schema: List[str] = [],
     exclude_dataset: List[str] = [],
     changed_since: Optional[str] = None,
+    filter_op: Operator = Operator.AND,
 ) -> Clause:
     shoulds: List[Clause] = names_query(entity)
     for prop, value in entity.itervalues():
@@ -130,6 +131,7 @@ def entity_query(
         dataset,
         shoulds,
         filters=filters,
+        filter_op=filter_op,
         schema=entity.schema,
         include_dataset=include_dataset,
         exclude_schema=exclude_schema,


### PR DESCRIPTION
This got changed by https://github.com/opensanctions/yente/pull/648.
