### PR TITLE
Fix adjacent expansion when root is interstitial and property name conflicts in mapping

### DIFF
--- a/yente/search/nested.py
+++ b/yente/search/nested.py
@@ -189,6 +189,12 @@ async def get_nested_entity(
             for adj_prop, value in adj.itervalues():
                 if adj_prop.type != registry.entity:
                     continue
+
+                # Loop-limiting condition:
+                #
+                # This expands in the next iteration, but only on edges.
+                # So we look beyond an adjacent edge like Directorship found from
+                # a Director, but not beyond a Director found from a Directorship.
                 if adj.schema.edge and value not in entities:
                     outbound_ids.add(value)
 

--- a/yente/search/nested.py
+++ b/yente/search/nested.py
@@ -86,7 +86,7 @@ def nest_entity(
 def initial_outbound_ids(entity: Entity, prop: Optional[Property] = None) -> Set[str]:
     if prop is None:
         return set(entity.get_type_values(registry.entity))
-    elif prop.schema.edge:
+    elif prop.type != registry.entity:
         return set()
     return set(entity.get(prop))
 


### PR DESCRIPTION
The adjacent API currently doesn't expand outgoing edges when the queried entity is an interstitial entity. This is because the logic for initial outgoing props was using the prop schema type rather than the prop type by mistake. The intention there is to only query for values that are entity IDs - I think I copied logic for expanding to edges when that's totally irrelevant there.

buggy

![image](https://github.com/user-attachments/assets/9d2f335a-bfbc-4050-9e13-fab0ce6f9d78)

less buggy

![image](https://github.com/user-attachments/assets/cdb1d1d5-2249-47a1-89e8-d574b08f6f9b)

---

![image](https://github.com/user-attachments/assets/46b04ea2-40dc-4dae-b3a0-945214e17da8)
