### PR TITLE
Google Cloud Logging compatible request logging

### DIFF
--- a/yente/middleware/__init__.py
+++ b/yente/middleware/__init__.py
@@ -1,3 +1,4 @@
+from .request_log import RequestLogMiddleware
 from .trace_context import TraceContextMiddleware
 
-__all__ = ["TraceContextMiddleware", "get_trace_context"]
+__all__ = ["RequestLogMiddleware", "TraceContextMiddleware", "get_trace_context"]

--- a/yente/middleware/request_log.py
+++ b/yente/middleware/request_log.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+import structlog
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from typing import Any, Callable, Awaitable, Optional
+
+from yente.logs import get_logger
+
+
+log = get_logger(__name__)
+
+
+def get_client_ip(request: Request) -> Optional[str]:
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        client_ip = forwarded_for.split(",")[0].strip()
+        return client_ip
+
+    return request.client.host if request.client else None
+
+
+class RequestLogMiddleware(BaseHTTPMiddleware):
+    """Middleware to set some log context based on the HTTP request."""
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        start_time = datetime.now()
+
+        http_request_info: dict[str, Any] = {
+            "requestMethod": request.method,
+            "requestUrl": str(request.url),
+            "userAgent": request.headers.get("User-Agent"),
+        }
+        if client_ip := get_client_ip(request):
+            http_request_info["remoteIp"] = client_ip
+        if referer := request.headers.get("referer"):
+            http_request_info["referer"] = referer
+
+        previous_contextvars = structlog.contextvars.bind_contextvars(
+            # This field is special in Google Cloud Logging, see
+            # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest
+            httpRequest=http_request_info,
+            # Not part of the Google-spec'd httpRequest object, but we want to capture the request path for easier filtering.
+            requestPath=request.url.path,
+        )
+
+        response = await call_next(request)
+
+        http_request_info["status"] = response.status_code
+        # Google Cloud LogEntry.HttpRequest specifies this is as a string like "0.5s",
+        # but that doesn't actually work - who knows why.
+        latency = datetime.now() - start_time
+        http_request_info["latency"] = {
+            "seconds": int(latency.total_seconds()),
+            "nanos": int(latency.microseconds * 1000),
+        }
+
+        log.info(
+            f"{request.method} {request.url.path}",
+            logType="request_completed",
+            httpRequest=http_request_info,
+        )
+
+        structlog.contextvars.reset_contextvars(**previous_contextvars)
+        return response

--- a/yente/middleware/trace_context.py
+++ b/yente/middleware/trace_context.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from typing import Any, Tuple, List
@@ -10,24 +11,27 @@ VENDOR_CODE = (
 )
 
 
+@dataclass
 class TraceParent:
-    __slots__ = ["version", "trace_id", "parent_id", "trace_flags"]
+    version: str
+    trace_id: str
+    parent_id: str
+    trace_flags: str
 
-    def __init__(self, version: str, trace_id: str, parent_id: str, trace_flags: str):
-        self.version = version
-        self.trace_id = trace_id
-        self.parent_id = parent_id
-        self.trace_flags = trace_flags
-
-    def __str__(self) -> str:
+    def as_header(self) -> str:
         return f"{self.version}-{self.trace_id}-{self.parent_id}-{self.trace_flags}"
 
     @classmethod
     def create(cls) -> "TraceParent":
-        return cls("00", secrets.token_hex(16), secrets.token_hex(8), "00")
+        return cls(
+            version="00",
+            trace_id=secrets.token_hex(16),
+            parent_id=secrets.token_hex(8),
+            trace_flags="00",
+        )
 
     @classmethod
-    def from_str(cls, traceparent: str | None) -> "TraceParent":
+    def from_header(cls, traceparent: str | None) -> "TraceParent":
         """
         Parse a traceparent header string into a TraceParent object created with a new parent_id.
         """
@@ -51,14 +55,17 @@ class TraceParent:
         else:
             raise ValueError(f"Invalid parent_id: {parent_id}")
 
-        return cls(version, trace_id, secrets.token_hex(8), trace_flags)
+        return cls(
+            version=version,
+            trace_id=trace_id,
+            parent_id=secrets.token_hex(8),
+            trace_flags=trace_flags,
+        )
 
 
+@dataclass
 class TraceState:
-    __slots__ = ["tracestate"]
-
-    def __init__(self, tracestate: List[Tuple[str, str]] = []):
-        self.tracestate = tracestate
+    tracestate: List[Tuple[str, str]]
 
     @classmethod
     def create(cls, parent: TraceParent, prev_state: str = "") -> "TraceState":
@@ -75,24 +82,14 @@ class TraceState:
         spans_out.insert(0, (VENDOR_CODE, f"{parent.parent_id}"))
         return cls(spans_out)
 
-    def __str__(self) -> str:
+    def as_header(self) -> str:
         return ",".join([f"{k}={v}" for k, v in self.tracestate])
 
 
+@dataclass
 class TraceContext:
-    __slots__ = ["traceparent", "tracestate"]
-
-    def __init__(self, traceparent: TraceParent, tracestate: TraceState):
-        self.traceparent = traceparent
-        self.tracestate = tracestate
-
-    def __repr__(self) -> str:
-        return str(
-            {
-                "traceparent": str(self.traceparent),
-                "tracestate": str(self.tracestate),
-            }
-        )
+    traceparent: TraceParent
+    tracestate: TraceState
 
 
 def get_trace_context() -> TraceContext | None:
@@ -108,9 +105,10 @@ class TraceContextMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Any) -> Any:
         parent_header = request.headers.get("traceparent")
         try:
-            traceparent = TraceParent.from_str(parent_header)
+            traceparent = TraceParent.from_header(parent_header)
         except Exception:
             traceparent = TraceParent.create()
+
         state = request.headers.get("tracestate", "")
         try:
             tracestate = TraceState.create(traceparent, state)
@@ -125,11 +123,11 @@ class TraceContextMiddleware(BaseHTTPMiddleware):
                 "logging.googleapis.com/spanId": context.traceparent.parent_id,
             }
         )
-
+        # Run the request
         resp = await call_next(request)
-
+        # Reset the logging contextvars to what they were before the request
         structlog.contextvars.reset_contextvars(**previous_contextvars)
 
-        resp.headers["traceparent"] = str(traceparent)
-        resp.headers["tracestate"] = str(tracestate)
+        resp.headers["traceparent"] = traceparent.as_header()
+        resp.headers["tracestate"] = tracestate.as_header()
         return resp

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -62,8 +62,8 @@ class ElasticSearchProvider(SearchProvider):
             arg_headers = kwargs.get("headers", {})
             headers = arg_headers | (
                 dict(
-                    traceparent=str(trace_context.traceparent),
-                    tracestate=str(trace_context.tracestate),
+                    traceparent=trace_context.traceparent.as_header(),
+                    tracestate=trace_context.tracestate.as_header(),
                 )
             )
             kwargs.update(headers=headers)


### PR DESCRIPTION
Google Cloud Logging has a magic httpRequest field in its LogEntry proto
that triggers special display logic (and more?). For all the people who
don't use Google Cloud, this isn't worse than what we had before. In
fact, it's better, case now we can process X-Fowarded-For.
