### PR TITLE
Implement passing scoring config in match request

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -30,6 +30,15 @@ def test_algorithms():
     assert "algorithms" in data
     assert len(data["algorithms"]) > 3
 
+    # Ensure that the logic-v2 algorithm is visible and that
+    # the configuration options are exposed
+    logic_v2 = next(
+        (a for a in data["algorithms"] if a["name"] == "UNSTABLE-logic-v2"), None
+    )
+    assert logic_v2 is not None
+    assert logic_v2["config"] is not None
+    assert logic_v2["config"]["nm_number_mismatch"] is not None
+
 
 def test_catalog():
     res = client.get("/catalog")

--- a/yente/data/common.py
+++ b/yente/data/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Union, Optional
 from pydantic import BaseModel, Field
-from nomenklatura.matching.types import MatchingResult, FeatureDocs
+from nomenklatura.matching.types import MatchingResult, FeatureDocs, ConfigVar
 
 from yente import settings
 from yente.data.dataset import YenteDatasetModel
@@ -121,6 +121,11 @@ class EntityExample(BaseModel):
 
 class EntityMatchQuery(BaseModel):
     weights: Dict[str, float] = Field({}, examples=[{"name_literal": 0.8}])
+    config: Dict[str, Union[str, int, float, bool]] = Field(
+        default_factory=dict,
+        description="Algorithm-specific configuration parameters.",
+        examples=[{"nm_number_mismatch": 0.4}],
+    )
     queries: Dict[str, EntityExample]
 
 
@@ -148,6 +153,9 @@ class Algorithm(BaseModel):
     name: str
     description: Optional[str] = None
     features: FeatureDocs
+    config: Dict[str, ConfigVar] = Field(
+        description="Algorithm-specific configuration parameters.",
+    )
 
 
 class AlgorithmResponse(BaseModel):

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -116,6 +116,7 @@ async def algorithms() -> AlgorithmResponse:
             name=algo.NAME,
             description=squash_spaces(algo.__doc__ or ""),
             features=algo.get_feature_docs(),
+            config=algo.CONFIG,
         )
         algorithms.append(desc)
     return AlgorithmResponse(

--- a/yente/routers/match.py
+++ b/yente/routers/match.py
@@ -136,6 +136,13 @@ async def match(
     limit, _ = limit_window(limit, 0, settings.MATCH_PAGE)
     algorithm_type = get_algorithm_by_name(algorithm)
 
+    for config_key in match.config.keys():
+        if config_key not in algorithm_type.CONFIG:
+            raise HTTPException(
+                400,
+                detail=f"Invalid configuration parameter: {config_key} for algorithm {algorithm_type.NAME}",
+            )
+
     if len(match.queries) > settings.MAX_BATCH:
         msg = "Too many queries in one batch (limit: %d)" % settings.MAX_BATCH
         raise HTTPException(400, detail=msg)
@@ -188,7 +195,7 @@ async def match(
             threshold=threshold,
             cutoff=cutoff,
             limit=limit,
-            config=ScoringConfig(weights=match.weights, config={}),
+            config=ScoringConfig(weights=match.weights, config=match.config),
         )
         log.info(
             f"/match/{ds.name}",


### PR DESCRIPTION
Also, expose the options in the `/algorithms` endpoint.

Fixes https://github.com/opensanctions/yente/issues/819