### PR TITLE
Index Entity.to_dict, rely on copy_to magic, add tests for that

### DIFF
--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,0 +1,91 @@
+import pytest
+
+from yente import settings
+from yente.search.mapping import INDEX_SETTINGS, make_entity_mapping
+from yente.data.entity import Entity
+from yente.search.indexer import build_indexable_entity_doc
+
+
+INDEX_MAPPINGS = make_entity_mapping()
+
+
+@pytest.mark.asyncio
+async def test_mappings_copy_to(search_provider):
+    """Test that all the mapping and indexing magic works.
+
+    We test that by executing queries on specific fields of the indexed documents."""
+    # Create a test index using the same settings as test_search_provider
+    temp_index = settings.ENTITY_INDEX + "-mappings-test"
+    try:
+        await search_provider.create_index(
+            temp_index, mappings=INDEX_MAPPINGS, settings=INDEX_SETTINGS
+        )
+
+        # Create a test entity with Vladimir Putin data
+        entity = Entity.from_dict(
+            {
+                "id": "Q7747",
+                "schema": "Person",
+                "properties": {
+                    "name": ["Vladimir Putin"],
+                    "citizenship": ["ru"],
+                    "topics": ["sanction"],
+                },
+                "datasets": ["test"],
+                "referents": [],
+                "first_seen": "2023-01-01T00:00:00",
+                "last_seen": "2023-01-01T00:00:00",
+                "last_change": "2023-01-01T00:00:00",
+            }
+        )
+
+        action = {
+            "_index": temp_index,
+            "_id": entity.id,
+            "_source": build_indexable_entity_doc(entity),
+        }
+        await search_provider.bulk_index([action])
+        await search_provider.refresh(temp_index)
+
+        # names is a text field, so need to use match
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"match": {"names": "Vladimir"}}]}}
+        )
+        assert len(search_result["hits"]["hits"]) == 1, "Failed to match on names"
+
+        # name_parts and name_phonetic are a bit of a special case, we syntesize them in the indexer
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"match": {"name_parts": "Vladimir"}}]}}
+        )
+        assert len(search_result["hits"]["hits"]) == 1, "Failed to match on name_parts"
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"match": {"name_phonetic": "FLTMR"}}]}}
+        )
+        assert (
+            len(search_result["hits"]["hits"]) == 1
+        ), "Failed to match on name_phonetic"
+
+        # Try to match on the countries field, which is a type field that is populated by copy_to from citizenship
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"term": {"countries": "ru"}}]}}
+        )
+        assert len(search_result["hits"]["hits"]) == 1, "Failed to match on countries"
+
+        # Try to match on the text field, which is a copy_to field that is populated by just about everything
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"term": {"text": "ru"}}]}}
+        )
+        assert (
+            len(search_result["hits"]["hits"]) == 1
+        ), "Failed to match country on text"
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"term": {"text": "sanction"}}]}}
+        )
+        assert len(search_result["hits"]["hits"]) == 1, "Failed to match topics on text"
+        search_result = await search_provider.search(
+            temp_index, {"bool": {"must": [{"match": {"text": "vladimir"}}]}}
+        )
+        assert len(search_result["hits"]["hits"]) == 1, "Failed to match name on text"
+    finally:
+        # Clean up the test index
+        await search_provider.delete_index(temp_index)

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -89,3 +89,13 @@ async def test_mappings_copy_to(search_provider):
     finally:
         # Clean up the test index
         await search_provider.delete_index(temp_index)
+
+
+def test_colliding_prop_names():
+    """Test that we can handle multiple properties with the same property name."""
+    mapping = make_entity_mapping()
+    # Yo dawg, I heard you like properties
+    prop_mapping = mapping["properties"]["properties"]["properties"]
+    # CallForTenders:authority is an entity, Identification:authority is a string
+    assert set(prop_mapping["authority"]["copy_to"]) == set(["text", "entities"])
+    assert prop_mapping["authority"]["type"] == "keyword"

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -1,7 +1,6 @@
 import asyncio
 import threading
 from typing import Any, AsyncGenerator, Dict, List
-from typing import Any, AsyncGenerator, AsyncIterable, Dict, List
 from followthemoney import registry
 from followthemoney.exc import FollowTheMoneyException
 from followthemoney.types.date import DateType
@@ -81,9 +80,6 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     entity_id = doc.pop("id")
     doc["entity_id"] = entity_id
 
-    # TODO(Leon Handreke): to_full_dict used to pass matchable=False (I think?)
-    # but that doesn't seem right? Does it matter, are there non-matchable names fields
-    # currently?
     names: List[str] = entity.get_type_values(registry.name, matchable=True)
     names.extend(entity.get("weakAlias", quiet=True))
 

--- a/yente/search/mapping.py
+++ b/yente/search/mapping.py
@@ -121,6 +121,9 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
             raise RuntimeError("Double mapping field: %s" % t.group)
         mapping[t.group] = make_type_field(t)
 
+    # These fields will be pruned from the _source field after the document has been
+    # indexed, but before the _source field is stored. We can still search on these fields,
+    # even though they are not in the stored and returned _source.
     drop_fields = [t.group for t in registry.groups.values()]
     drop_fields.append("text")
     drop_fields.append(NAME_PHONETIC_FIELD)


### PR DESCRIPTION
Previously, the NAME_{KEY,PART,PHONETIC} fields were built from the
`names` type field generated by `to_full_dict`. That's no longer being
called, so we're now pulling out the names using
`Entity.get_type_values` in `build_indexable_entity_doc` to do further
shenanigans on the names.

See https://github.com/opensanctions/yente/issues/806
