### PR TITLE
Log detail about the coordinating node and serving shards in debug mode

### DIFF
--- a/yente/cli.py
+++ b/yente/cli.py
@@ -33,14 +33,14 @@ def serve() -> None:
             server_header=False,
         ),
     )
-    configure_logging()
+    configure_logging(settings.LOG_LEVEL)
     server.run()
 
 
 @cli.command("reindex", help="Re-index the data if newer data is available")
 @click.option("-f", "--force", is_flag=True, default=False)
 def reindex(force: bool) -> None:
-    configure_logging()
+    configure_logging(settings.LOG_LEVEL)
     asyncio.run(update_index(force=force))
 
 
@@ -54,7 +54,7 @@ async def _clear_index() -> None:
 
 @cli.command("clear-index", help="Delete everything in ElasticSearch")
 def clear_index() -> None:
-    configure_logging()
+    configure_logging(settings.LOG_LEVEL)
     asyncio.run(_clear_index())
 
 

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -206,6 +206,8 @@ class ElasticSearchProvider(SearchProvider):
                     sort=sort,
                     aggregations=aggregations,
                     search_type=search_type,
+                    explain=settings.DEBUG,
+                    track_total_hits=settings.DEBUG,
                 )
                 return cast(Dict[str, Any], response.body)
         except TransportError as te:


### PR DESCRIPTION
This has a performance impact because it enables explain and counting total possible results from elasticsearch.

Do we want it to be a different option than YENTE_DEBUG?