### PR TITLE
Put system_version in index alias name to allow for blue-green rollouts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ VERSIONS_PATH = FIXTURES_PATH / "versions.json"
 MANIFEST_PATH = FIXTURES_PATH / "manifest.yml"
 settings.MANIFEST = str(MANIFEST_PATH)
 settings.INDEX_NAME = f"yente-test-{run_id}"
-settings.ENTITY_INDEX = f"{settings.INDEX_NAME}-entities"
 settings.AUTO_REINDEX = False
 
 app = create_app()

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -15,7 +15,7 @@ async def test_mappings_copy_to(search_provider):
 
     We test that by executing queries on specific fields of the indexed documents."""
     # Create a test index using the same settings as test_search_provider
-    temp_index = settings.ENTITY_INDEX + "-mappings-test"
+    temp_index = settings.INDEX_NAME + "-mappings-test"
     try:
         await search_provider.create_index(
             temp_index, mappings=INDEX_MAPPINGS, settings=INDEX_SETTINGS

--- a/tests/test_search_provider.py
+++ b/tests/test_search_provider.py
@@ -15,11 +15,11 @@ TEST_SETTINGS = INDEX_SETTINGS
 async def test_provider_core(search_provider: SearchProvider):
     # Not sure what to test....
     with pytest.raises(YenteNotFoundError):
-        fake_index = settings.ENTITY_INDEX + "-doesnt-exist"
+        fake_index = settings.INDEX_NAME + "-doesnt-exist"
         await search_provider.refresh(fake_index)
         await search_provider.check_health(fake_index)
 
-    temp_index = settings.ENTITY_INDEX + "-provider-admin"
+    temp_index = settings.INDEX_NAME + "-provider-admin"
     await search_provider.create_index(
         temp_index, mappings=TEST_MAPPINGS, settings=TEST_SETTINGS
     )
@@ -32,7 +32,7 @@ async def test_provider_core(search_provider: SearchProvider):
 async def test_index_lifecycle(search_provider: SearchProvider):
     # Given a non-existent index
     # When creating it we should return nothing
-    temp_index = settings.ENTITY_INDEX + "-provider-test"
+    temp_index = settings.INDEX_NAME + "-provider-test"
     pre_indices = await search_provider.get_all_indices()
     assert temp_index not in pre_indices
     await search_provider.create_index(
@@ -61,7 +61,7 @@ async def test_index_lifecycle(search_provider: SearchProvider):
 
 @pytest.mark.asyncio
 async def test_alias_management(search_provider: SearchProvider):
-    alias = settings.ENTITY_INDEX + "-alias"
+    alias = settings.INDEX_NAME + "-alias"
     prefix = alias + "-prefix"
     index_v1 = prefix + "-v1"
     index_v2 = prefix + "-v2"

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -14,6 +14,7 @@ from yente.provider import SearchProvider, get_provider
 from yente.routers.util import ENABLED_ALGORITHMS
 from yente.search.indexer import update_index, update_index_threaded
 from yente.search.status import sync_dataset_versions
+from yente.search.versions import get_index_alias_name
 
 log = get_logger(__name__)
 router = APIRouter()
@@ -60,7 +61,7 @@ async def readyz(
 ) -> StatusResponse:
     """Search index health check. This is used to know if the service has completed
     its index building."""
-    ok = await provider.check_health(index=settings.ENTITY_INDEX)
+    ok = await provider.check_health(index=get_index_alias_name())
     if not ok:
         raise HTTPException(503, detail="Index not ready.")
     return StatusResponse(status="ok")

--- a/yente/search/audit_log.py
+++ b/yente/search/audit_log.py
@@ -5,6 +5,7 @@ import random
 from typing import Any, Dict, Optional, cast
 from yente import logs, settings
 from yente.provider.base import SearchProvider
+from yente.search.versions import get_index_alias_name, get_system_version
 
 
 # Query the audit log using the following query:
@@ -17,7 +18,7 @@ log = logs.get_logger(__name__)
 
 
 def get_audit_log_index_name() -> str:
-    return f"{settings.INDEX_NAME}-audit-log"
+    return f"{settings.INDEX_NAME}-{get_system_version()}-audit-log"
 
 
 def millis_timestamp_to_datetime(timestamp: int) -> datetime:
@@ -95,7 +96,7 @@ async def log_audit_message(
                 "_index": get_audit_log_index_name(),
                 "_id": doc_id,
                 "_source": {
-                    "alias_index": settings.ENTITY_INDEX,
+                    "alias_index": get_index_alias_name(),
                     "index": index,
                     "dataset": dataset,
                     "dataset_version": dataset_version,

--- a/yente/search/nested.py
+++ b/yente/search/nested.py
@@ -15,6 +15,7 @@ from yente.data.common import (
 )
 from yente.provider import SearchProvider
 from yente.search.search import result_entities, result_total
+from yente.search.versions import get_index_alias_name
 
 log = get_logger(__name__)
 
@@ -168,7 +169,7 @@ async def get_nested_entity(
             }
         }
         resp = await provider.search(
-            index=settings.ENTITY_INDEX,
+            index=get_index_alias_name(),
             query=query,
             size=limit,
             from_=offset,

--- a/yente/search/search.py
+++ b/yente/search/search.py
@@ -3,12 +3,12 @@ from typing import Any, Dict, List, Optional
 from followthemoney import model, registry, Schema
 from followthemoney.dataset import DataCatalog
 
-from yente import settings
 from yente.logs import get_logger
 from yente.data.dataset import Dataset
 from yente.data.entity import Entity
 from yente.data.common import SearchFacet, SearchFacetItem, TotalSpec
 from yente.provider import SearchProvider
+from yente.search.versions import get_index_alias_name
 from yente.util import EntityRedirect
 
 log = get_logger(__name__)
@@ -110,7 +110,7 @@ async def search_entities(
     sort: List[Any] = [],
 ) -> Dict[str, Any]:
     return await provider.search(
-        index=settings.ENTITY_INDEX,
+        index=get_index_alias_name(),
         query=query,
         size=limit,
         sort=sort,
@@ -131,7 +131,7 @@ async def get_entity(provider: SearchProvider, entity_id: str) -> Optional[Entit
         }
     }
     response = await provider.search(
-        index=settings.ENTITY_INDEX,
+        index=get_index_alias_name(),
         query=query,
         size=2,
     )
@@ -153,7 +153,7 @@ async def get_matchable_schemata(
     filter_ = {"terms": {"datasets": dataset.dataset_names}}
     facet = "schemata"
     response = await provider.search(
-        index=settings.ENTITY_INDEX,
+        index=get_index_alias_name(),
         query={"bool": {"filter": [filter_]}},
         size=0,
         aggregations={facet: {"terms": {"field": "schema", "size": 1000}}},

--- a/yente/search/status.py
+++ b/yente/search/status.py
@@ -1,14 +1,13 @@
-from yente import settings
 from yente.logs import get_logger
 from yente.provider import SearchProvider
-from yente.search.versions import parse_index_name
+from yente.search.versions import get_index_alias_name, parse_index_name
 from yente.data.manifest import Catalog
 
 log = get_logger(__name__)
 
 
 async def sync_dataset_versions(provider: SearchProvider, catalog: Catalog) -> None:
-    for aliased_index in await provider.get_alias_indices(settings.ENTITY_INDEX):
+    for aliased_index in await provider.get_alias_indices(get_index_alias_name()):
         try:
             index_info = parse_index_name(aliased_index)
         except ValueError:

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -199,7 +199,6 @@ INDEX_CA_CERT = None if _INDEX_CA_CERT == "" else _INDEX_CA_CERT
 INDEX_SHARDS = int(env_legacy("YENTE_INDEX_SHARDS", "YENTE_ELASTICSEARCH_SHARDS", "1"))
 INDEX_AUTO_REPLICAS = env_str("YENTE_INDEX_AUTO_REPLICAS", "0-all")
 INDEX_NAME = env_legacy("YENTE_INDEX_NAME", "YENTE_ELASTICSEARCH_INDEX", "yente")
-ENTITY_INDEX = f"{INDEX_NAME}-entities"
 # Bump this when the index format changes and a full reindex is required.
 # Be careful to make the query code compatible with the old index format, otherwise
 # yente will be unable to serve requests after the upgrade until the first reindex completes.


### PR DESCRIPTION
- **Put system_version in index alias name to allow for blue-green rollouts**
  This effectively makes the system version (i.e. the yente index version as well as the FtM version) part of the namespace that yente is operating and touching things in. Things outside the namespace should not be touched at all.
  
  The idea would be for a new `yente reindex` to run, set up the new alias, while the old version can keep serving from the old alias.
  