### PR TITLE
Log HTTP error URL explicitly

### DIFF
--- a/yente/data/__init__.py
+++ b/yente/data/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import httpx
 import structlog
 from structlog.stdlib import BoundLogger
 
@@ -22,5 +23,7 @@ async def refresh_catalog() -> None:
     log.info("Refreshing manifest/catalog...", catalog=Catalog.instance)
     try:
         Catalog.instance = await Catalog.load()
+    except httpx.HTTPError as exc:
+        log.exception("Metadata fetch error (%s): %s" % (exc.request.url, exc))
     except (Exception, KeyboardInterrupt) as exc:
         log.exception("Metadata fetch error: %s" % exc)


### PR DESCRIPTION
Turns

```
2025-10-03T08:58:39.572313Z [info     ] HTTP Request: GET https://data.opensanctions.org/datasets/latest/index.json "HTTP/1.1 200 OK" [httpx]
2025-10-03T08:58:41.178931Z [error    ] Metadata fetch error: All connection attempts failed [yente.data]
Traceback (most recent call last):
  File "/Users/jdb/projects/opensanctions/yente/venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
```

into

```
2025-10-03T09:05:58.711496Z [info     ] HTTP Request: GET https://data.opensanctions.org/datasets/latest/index.json "HTTP/1.1 200 OK" [httpx]
2025-10-03T09:06:00.322744Z [error    ] Metadata fetch error (http://localhost:3000/graph.catalog.json): All connection attempts failed [yente.data]
Traceback (most recent call last):
  File "/Users/jdb/projects/opensanctions/yente/venv/lib/python3.12/site-packages/httpx/_transports/default.py", line 101, in map_httpcore_exceptions
```

Which occurs when you start fiddling with custom data sources.

This is cleaner than sprinkling `catch HttpError` all over `yente.data.loader`, but is leaking httpx into `yente.data` worth it?