### PR TITLE
doc(index.md):fix double slash in hosted API link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # yente - the [matchmaker](https://www.youtube.com/watch?v=jVGNdB6iEeA)
 
-yente is an open source screening API service that powers the [hosted OpenSanctions API]({{ config.extra.opensanctions_url }}//api/). It provides functions search, retrieve or match FollowTheMoney entities, including people, companies or vessels that are subject to international sanctions.
+yente is an open source screening API service that powers the [hosted OpenSanctions API]({{ config.extra.opensanctions_url }}/api/). It provides functions search, retrieve or match FollowTheMoney entities, including people, companies or vessels that are subject to international sanctions.
 
 Out of the box, it provides access to [OpenSanctions data]({{ config.extra.opensanctions_url}}/datasets/), but it can also be used to [search and match other data](datasets.md), such as [company registries]({{ config.extra.opensanctions_url }}/kyb/) or [custom watchlists](datasets.md). It can also be run [on-premises as a KYC appliance]({{ config.extra.opensanctions_url }}/docs/on-premise/) so that no customer data leaves the deployment context.
 


### PR DESCRIPTION
Fix: removed the extra slash in hosted API link that was giving this error:
<img width="1864" height="260" alt="image" src="https://github.com/user-attachments/assets/6550bb4c-9a74-4336-b084-43d9f2d8bd6e" />


**Before**: `{{ config.extra.opensanctions_url }}//api/` → `https://www.opensanctions.org//api/`

**After**: `{{ config.extra.opensanctions_url }}/api/` → `https://www.opensanctions.org/api/`