### PR TITLE
docs(settings.md): update YENTE_QUERY_CONCURRENCY default to 50

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,6 +35,6 @@ Yente features various configuration options related to data refresh and re-inde
 | `YENTE_MAX_MATCHES` | `500` | How many results to return per `/match` query at most. |
 | `YENTE_MATCH_CANDIDATES` | `10` | How many candidates to retrieve from the search as a multiplier of the `/match` limit. Note that increasing this parameter will also increase query cost, as each of these candidates scored after retrieval from the index.|
 | `YENTE_MATCH_FUZZY` | `true` | Whether to run expensive Levenshtein queries inside ElasticSearch. |
-| `YENTE_QUERY_CONCURRENCY` | `10` | How many match and search queries to run against ES in parallel. |
+| `YENTE_QUERY_CONCURRENCY` | `50` | How many match and search queries to run against ES in parallel. |
 | `YENTE_DELTA_UPDATES` | `true` | When set to `false` Yente will download the entire dataset when refreshing the index. |
 | `YENTE_STREAM_LOAD`   | `true`   | If set to `false`, will download the full data before indexing it. This can improve the stability of the indexer, especially when the network connection is a bit sketchy, but requires some local disk cache space.   |


### PR DESCRIPTION
**Update:** 
YENTE_QUERY_CONCURRENCY default value in documentation

**Before:** 
Default listed as 10

**After:** 
Default listed as 50

**Context:** 
Aligns docs/settings.md with the default value in yente/settings.py
