### PR TITLE
provider: get rid of YENTE_QUERY_CONCURRENCY env variable and sempahore

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,6 +35,5 @@ Yente features various configuration options related to data refresh and re-inde
 | `YENTE_MAX_MATCHES` | `500` | How many results to return per `/match` query at most. |
 | `YENTE_MATCH_CANDIDATES` | `10` | How many candidates to retrieve from the search as a multiplier of the `/match` limit. Note that increasing this parameter will also increase query cost, as each of these candidates scored after retrieval from the index.|
 | `YENTE_MATCH_FUZZY` | `true` | Whether to run expensive Levenshtein queries inside ElasticSearch. |
-| `YENTE_QUERY_CONCURRENCY` | `50` | How many match and search queries to run against ES in parallel. |
 | `YENTE_DELTA_UPDATES` | `true` | When set to `false` Yente will download the entire dataset when refreshing the index. |
 | `YENTE_STREAM_LOAD`   | `true`   | If set to `false`, will download the full data before indexing it. This can improve the stability of the indexer, especially when the network connection is a bit sketchy, but requires some local disk cache space.   |

--- a/yente/provider/base.py
+++ b/yente/provider/base.py
@@ -1,14 +1,7 @@
-from asyncio import Semaphore
 from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Union
-
-from yente import settings
 
 
 class SearchProvider(object):
-    def __init__(self) -> None:
-        # We create a provider instance per event loop. Semaphone gets attached
-        # to the event loop, so it has to be scoped to the provider instance.
-        self.query_semaphore = Semaphore(settings.QUERY_CONCURRENCY)
 
     async def close(self) -> None:
         raise NotImplementedError

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -197,17 +197,16 @@ class ElasticSearchProvider(SearchProvider):
         search_type = "dfs_query_then_fetch" if rank_precise else None
 
         try:
-            async with self.query_semaphore:
-                response = await self.client().search(
-                    index=index,
-                    query=query,
-                    size=size,
-                    from_=from_,
-                    sort=sort,
-                    aggregations=aggregations,
-                    search_type=search_type,
-                )
-                return cast(Dict[str, Any], response.body)
+            response = await self.client().search(
+                index=index,
+                query=query,
+                size=size,
+                from_=from_,
+                sort=sort,
+                aggregations=aggregations,
+                search_type=search_type,
+            )
+            return cast(Dict[str, Any], response.body)
         except TransportError as te:
             log.warning(
                 f"Backend connection error: {te.message}",
@@ -245,9 +244,8 @@ class ElasticSearchProvider(SearchProvider):
         Returns the document if found, None if not found.
         """
         try:
-            async with self.query_semaphore:
-                response = await self.client().get(index=index, id=doc_id)
-                return cast(Dict[str, Any], response.body)
+            response = await self.client().get(index=index, id=doc_id)
+            return cast(Dict[str, Any], response.body)
         except NotFoundError:
             return None
         except Exception as exc:

--- a/yente/provider/opensearch.py
+++ b/yente/provider/opensearch.py
@@ -212,20 +212,19 @@ class OpenSearchProvider(SearchProvider):
         search_type = "dfs_query_then_fetch" if rank_precise else None
 
         try:
-            async with self.query_semaphore:
-                body: Dict[str, Any] = {"query": query}
-                if aggregations is not None:
-                    body["aggregations"] = aggregations
-                if sort is not None:
-                    body["sort"] = sort
-                response = await self.client.search(
-                    index=index,
-                    size=size,
-                    from_=from_,
-                    body=body,
-                    search_type=search_type,
-                )
-                return cast(Dict[str, Any], response)
+            body: Dict[str, Any] = {"query": query}
+            if aggregations is not None:
+                body["aggregations"] = aggregations
+            if sort is not None:
+                body["sort"] = sort
+            response = await self.client.search(
+                index=index,
+                size=size,
+                from_=from_,
+                body=body,
+                search_type=search_type,
+            )
+            return cast(Dict[str, Any], response)
         except TransportError as exc:
             if "index_not_found_exception" in exc.error:
                 msg = (
@@ -258,9 +257,8 @@ class OpenSearchProvider(SearchProvider):
         Returns the document if found, None if not found.
         """
         try:
-            async with self.query_semaphore:
-                response = await self.client.get(index=index, id=doc_id)
-                return cast(Dict[str, Any], response)
+            response = await self.client.get(index=index, id=doc_id)
+            return cast(Dict[str, Any], response)
         except NotFoundError:
             return None
         except Exception as exc:

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -169,9 +169,6 @@ MATCH_CANDIDATES = env_int("YENTE_MATCH_CANDIDATES", 10)
 # Whether to run expensive levenshtein queries inside ElasticSearch:
 MATCH_FUZZY = as_bool(env_str("YENTE_MATCH_FUZZY", "true"))
 
-# How many match and search queries to run against ES in parallel:
-QUERY_CONCURRENCY = env_int("YENTE_QUERY_CONCURRENCY", 50)
-
 # Default scoring threshold for /match results:
 SCORE_THRESHOLD = 0.70
 


### PR DESCRIPTION
Turns out, a single yente instance overloading an Elastic index is never ever a problem. This allows us to get rid of a tiny bit of complexity, so why not.

Fixes https://github.com/opensanctions/yente/issues/999
