### PR TITLE
provider/elastic: surface sample BulkIndexError detail

### DIFF
--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -273,4 +273,11 @@ class ElasticSearchProvider(SearchProvider):
                 stats_only=True,
             )
         except BulkIndexError as exc:
-            raise YenteIndexError(f"Could not index entities: {exc}") from exc
+            sample = exc.errors[:3] if exc.errors else []
+            log.warning(
+                f"Bulk index failed: {len(exc.errors)} document(s) rejected",
+                errors=sample,
+            )
+            raise YenteIndexError(
+                f"Could not index entities: {exc} (see log for sample errors)"
+            ) from exc


### PR DESCRIPTION
## Summary

- The ES provider's `bulk_index` was catching `BulkIndexError` and re-raising with only the failure count, discarding `exc.errors` — so "N document(s) failed to index" was unactionable.
- Log a sample (first 3) of the per-document rejection payloads as a structured `log.warning` before re-raising. Mirrors the `TransportError` handling a few lines above (`errors=te.errors`).
- Append `(see log for sample errors)` to the `YenteIndexError` message so readers of the outer exception log line (`indexer.py:230`) know where the detail is.

Fixes #1108.

## Test plan

- [ ] `pytest tests/test_mappings.py -xvs` (happy path: bulk_index still succeeds on valid docs)
- [ ] Manual: point yente at a test ES cluster with a deliberately malformed entity (e.g. a non-parsable date in a `date`-typed property) and confirm the yente log now contains a `Bulk index failed: N document(s) rejected` warning with an `errors=[{...'type': 'mapper_parsing_exception'...}]` structured field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)