### PR TITLE
Add Subresource Integrity for ReDoc bundle

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,35 @@
 import json
+import pytest
 
+from fastapi.testclient import TestClient
+
+from yente import settings
+from yente.app import create_app
 from .conftest import client
 
 EXAMPLE = {
     "schema": "Person",
     "properties": {"name": ["Vladimir Putin"]},
 }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def load_data():
+    """Shadow the ES-requiring load_data fixture from conftest for this module.
+    Tests here that need indexed data must request it explicitly."""
+    yield
+
+
+def test_redoc_has_sri():
+    """ReDoc docs page must reference the versioned URL and include SRI attributes.
+    GET / is pure HTML with no Elasticsearch dependency."""
+    c = TestClient(create_app())
+    res = c.get("/")
+    assert res.status_code == 200
+    html = res.text
+    assert f'src="{settings.REDOC_JS_URL}"' in html, "ReDoc script tag missing"
+    assert f'integrity="{settings.REDOC_JS_SRI}"' in html, "SRI integrity attribute missing"
+    assert 'crossorigin="anonymous"' in html, "crossorigin attribute missing"
 
 
 def test_match_without_content_type_header():

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -38,9 +38,23 @@ async def redoc_html() -> HTMLResponse:
     # script's SHA-384 hash before executing it. If the server ever delivers a different
     # file the hash won't match and the browser refuses to run it.
     # Update YENTE_REDOC_JS_URL and YENTE_REDOC_JS_SRI together when upgrading ReDoc.
-    html = bytes(response.body).decode("utf-8").replace(
-        f'src="{settings.REDOC_JS_URL}"',
-        f'src="{settings.REDOC_JS_URL}" integrity="{settings.REDOC_JS_SRI}" crossorigin="anonymous"',
+    # onerror fires on SRI mismatch or network failure (unlike <noscript>, which only
+    # fires when JavaScript is disabled entirely).
+    fallback = (
+        '<p id="redoc-error" style="display:none;padding:2em">'
+        "If you see this, you may need to update <code>YENTE_REDOC_JS_SRI</code> "
+        "to match the script at <code>YENTE_REDOC_JS_URL</code>.</p>"
+    )
+    html = (
+        bytes(response.body)
+        .decode("utf-8")
+        .replace(
+            f'src="{settings.REDOC_JS_URL}"',
+            f'src="{settings.REDOC_JS_URL}" integrity="{settings.REDOC_JS_SRI}"'
+            ' crossorigin="anonymous"'
+            ' onerror="document.getElementById(\'redoc-error\').style.display=\'block\'"',
+        )
+        .replace("<redoc ", f"{fallback}\n    <redoc ")
     )
     return HTMLResponse(html)
 

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -25,14 +25,24 @@ router = APIRouter()
     include_in_schema=False,
 )
 async def redoc_html() -> HTMLResponse:
-    """Render the ReDoc API documentation renderer script."""
-    return get_redoc_html(
+    """Render the ReDoc API documentation page."""
+    response = get_redoc_html(
         openapi_url="/openapi.json",
         title=settings.TITLE,
-        redoc_js_url="https://assets.opensanctions.org/scripts/redoc.standalone.js",
+        redoc_js_url=settings.REDOC_JS_URL,
         redoc_favicon_url="https://assets.opensanctions.org/images/nura/favicon-32.png",
         with_google_fonts=False,
     )
+    # get_redoc_html produces a plain <script src="..."> tag with no integrity check.
+    # We inject Subresource Integrity (SRI) attributes so the browser verifies the
+    # script's SHA-384 hash before executing it. If the server ever delivers a different
+    # file the hash won't match and the browser refuses to run it.
+    # Update YENTE_REDOC_JS_URL and YENTE_REDOC_JS_SRI together when upgrading ReDoc.
+    html = bytes(response.body).decode("utf-8").replace(
+        f'src="{settings.REDOC_JS_URL}"',
+        f'src="{settings.REDOC_JS_URL}" integrity="{settings.REDOC_JS_SRI}" crossorigin="anonymous"',
+    )
+    return HTMLResponse(html)
 
 
 @router.get(

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -223,8 +223,7 @@ RUN_DT = utc_now()
 # ReDoc API documentation bundle, served at GET /.
 # URL is versioned so the path is stable and the SRI hash doesn't need updating
 # unless you deliberately upgrade. To upgrade:
-#   1. Update REDOC_VERSION in knowledgebase/Makefile and run `make assets`
-#      hosted in assets.opensanctions.org to address security / privacy concerns
+#   1. Hosted in assets.opensanctions.org to address security / privacy concerns
 #   2. Update the URL and recompute the hash:
 #      curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
 REDOC_JS_URL = env_str(

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -220,7 +220,7 @@ LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 # Used to pad out first_seen, last_seen on static collections
 RUN_DT = utc_now()
 
-# ReDoc API documentation bundle, served at GET /.
+# ReDoc API documentation bundle used by API documentation page served at `/`.
 # URL is versioned so the path is stable and the SRI hash doesn't need updating
 # unless you deliberately upgrade. To upgrade:
 #   1. Hosted in assets.opensanctions.org to address security / privacy concerns

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -223,12 +223,13 @@ RUN_DT = utc_now()
 # ReDoc API documentation bundle, served at GET /.
 # URL is versioned so the path is stable and the SRI hash doesn't need updating
 # unless you deliberately upgrade. To upgrade:
-#   1. Update REDOC_VERSION in knowledgebase/Makefile and run `make assets`
-#   2. Update the URL and recompute the hash:
+#   1. Update REDOC_VERSION
+#   2. Recompute the hash:
 #      curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
+REDOC_VERSION = "2.5.2"
 REDOC_JS_URL = env_str(
     "YENTE_REDOC_JS_URL",
-    "https://assets.opensanctions.org/scripts/redoc-2.5.2.standalone.js",
+    f"https://cdn.redoc.ly/redoc/v{REDOC_VERSION}/bundles/redoc.standalone.js",
 )
 REDOC_JS_SRI = env_str(
     "YENTE_REDOC_JS_SRI",

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -224,6 +224,7 @@ RUN_DT = utc_now()
 # URL is versioned so the path is stable and the SRI hash doesn't need updating
 # unless you deliberately upgrade. To upgrade:
 #   1. Update REDOC_VERSION in knowledgebase/Makefile and run `make assets`
+#      hosted in assets.opensanctions.org to address security / privacy concerns
 #   2. Update the URL and recompute the hash:
 #      curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
 REDOC_JS_URL = env_str(

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -223,13 +223,12 @@ RUN_DT = utc_now()
 # ReDoc API documentation bundle, served at GET /.
 # URL is versioned so the path is stable and the SRI hash doesn't need updating
 # unless you deliberately upgrade. To upgrade:
-#   1. Update REDOC_VERSION
-#   2. Recompute the hash:
+#   1. Update REDOC_VERSION in knowledgebase/Makefile and run `make assets`
+#   2. Update the URL and recompute the hash:
 #      curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
-REDOC_VERSION = "2.5.2"
 REDOC_JS_URL = env_str(
     "YENTE_REDOC_JS_URL",
-    f"https://cdn.redoc.ly/redoc/v{REDOC_VERSION}/bundles/redoc.standalone.js",
+    "https://assets.opensanctions.org/scripts/redoc-2.5.2.standalone.js",
 )
 REDOC_JS_SRI = env_str(
     "YENTE_REDOC_JS_SRI",

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -219,3 +219,18 @@ LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 
 # Used to pad out first_seen, last_seen on static collections
 RUN_DT = utc_now()
+
+# ReDoc API documentation bundle, served at GET /.
+# URL is versioned so the path is stable and the SRI hash doesn't need updating
+# unless you deliberately upgrade. To upgrade:
+#   1. Update REDOC_VERSION in knowledgebase/Makefile and run `make assets`
+#   2. Update the URL and recompute the hash:
+#      curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
+REDOC_JS_URL = env_str(
+    "YENTE_REDOC_JS_URL",
+    "https://assets.opensanctions.org/scripts/redoc-2.5.2.standalone.js",
+)
+REDOC_JS_SRI = env_str(
+    "YENTE_REDOC_JS_SRI",
+    "sha384-70P5pmIdaQdVbxvjhrcTDv1uKcKqalZ3OHi7S2J+uzDl0PW8dO6L+pHOpm9EEjGJ",
+)


### PR DESCRIPTION
Requires https://github.com/opensanctions/knowledgebase/pull/22

## Summary

- Pins the ReDoc bundle to a versioned URL (`redoc-2.5.2.standalone.js`) instead of a floating path
- Injects `integrity` and `crossorigin` attributes onto the `<script>` tag so the browser verifies the SHA-384 hash before executing the file — a tampered or substituted bundle will be rejected
- Adds `YENTE_REDOC_JS_URL` and `YENTE_REDOC_JS_SRI` env vars for operators who need to override the defaults

## Upgrading ReDoc

1. Bump `REDOC_VERSION` in `knowledgebase/Makefile` and run `make assets` to upload the new bundle to `assets.opensanctions.org`
2. Update `YENTE_REDOC_JS_URL` to the new versioned path and recompute the hash:
   ```
   curl -sL <new_url> | openssl dgst -sha384 -binary | openssl base64 -A
   ```
3. Update `YENTE_REDOC_JS_SRI` with the result (prefixed `sha384-`)

## Test plan

- [x] `pytest tests/test_app.py::test_redoc_has_sri` passes without Elasticsearch
- [x] `GET /` on a running instance renders the ReDoc docs page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
