### PR TITLE
Add indexed_dataset_version_time OTel gauge

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,22 @@ from followthemoney import model
 from followthemoney.dataset.util import dataset_name_check
 import orjson
 
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
 from yente import settings
 from yente.app import create_app
 from yente.search.indexer import update_index
 from yente.provider import with_provider, close_provider
 from yente.data.manifest import Catalog, Manifest
 import yente.data
+
+
+# In-memory OpenTelemetry metric reader so tests can assert on gauge values.
+# MeterProvider can only be set once globally, so we wire it up at module import.
+metric_reader = InMemoryMetricReader()
+metrics.set_meter_provider(MeterProvider(metric_readers=[metric_reader]))
 
 
 @asynccontextmanager

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,49 +1,131 @@
+from datetime import datetime
+
 import pytest
 import pytest_asyncio
 
 from yente import settings
 from yente.data import get_catalog
 from yente.data.manifest import Manifest
+from yente.data.metrics import update_dataset_version_metric
 from yente.provider import SearchProvider
 from yente.search.indexer import update_index
+from yente.search.mapping import INDEX_SETTINGS, make_entity_mapping
 from yente.search.versions import build_index_name
 
 from tests.conftest import (
-    PARTEISPENDEN_MANIFEST,
+    ZALA_MANIFEST,
     build_index_alias_name_for_fixture,
+    metric_reader,
     patch_yente_catalog,
 )
 
 
-LAST_EXPORT_ISO = "2026-05-15T12:34:56"
+INITIAL_LAST_EXPORT_ISO = "2026-05-15T12:34:56+00:00"
+UPDATED_LAST_EXPORT_ISO = "2026-06-10T08:00:00+00:00"
 
-_manifest_dict = PARTEISPENDEN_MANIFEST.model_dump(mode="json")
-_manifest_dict["datasets"][0]["last_export"] = LAST_EXPORT_ISO
-PARTEISPENDEN_WITH_LAST_EXPORT_MANIFEST = Manifest.model_validate(_manifest_dict)
+
+def _zala_manifest_with_last_export(version: str, last_export_iso: str) -> Manifest:
+    # Pin `version` explicitly: otherwise yente derives it from the local
+    # entities file's mtime, which doesn't change with `last_export`.
+    data = ZALA_MANIFEST.model_dump(mode="json")
+    data["datasets"][0]["version"] = version
+    data["datasets"][0]["last_export"] = last_export_iso
+    return Manifest.model_validate(data)
+
+
+ZALA_WITH_INITIAL_LAST_EXPORT_MANIFEST = _zala_manifest_with_last_export(
+    "v1", INITIAL_LAST_EXPORT_ISO
+)
+ZALA_WITH_UPDATED_LAST_EXPORT_MANIFEST = _zala_manifest_with_last_export(
+    "v2", UPDATED_LAST_EXPORT_ISO
+)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def parteispenden_with_last_export(monkeypatch):
+async def zala_with_last_export(monkeypatch):
     monkeypatch.setattr(
         settings,
         "ENTITY_INDEX",
-        build_index_alias_name_for_fixture("parteispenden-last-export"),
+        build_index_alias_name_for_fixture("zala-last-export"),
     )
-    async with patch_yente_catalog(PARTEISPENDEN_WITH_LAST_EXPORT_MANIFEST):
+    async with patch_yente_catalog(ZALA_WITH_INITIAL_LAST_EXPORT_MANIFEST):
         await update_index()
         yield
 
 
+def _gauge_values_by_dataset(metric_name: str) -> dict[str, float]:
+    """Return a {dataset -> value} dict of the most recent values for the named
+    gauge across all `dataset` attribute labels."""
+    result: dict[str, float] = {}
+    data = metric_reader.get_metrics_data()
+    if data is None:
+        return result
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != metric_name:
+                    continue
+                for point in metric.data.data_points:
+                    dataset = point.attributes.get("dataset")
+                    if dataset is not None:
+                        result[dataset] = point.value
+    return result
+
+
 @pytest.mark.asyncio
 async def test_index_entities_writes_last_export_to_metadata(
-    parteispenden_with_last_export,
+    zala_with_last_export,
     search_provider: SearchProvider,
 ):
     """index_entities should write dataset.model.last_export into the index
     `_meta` so it survives the load and can be read back."""
     catalog = await get_catalog()
-    dataset = catalog.require("parteispenden")
+    dataset = catalog.require("zala")
     assert dataset.model.version is not None
     index = build_index_name(dataset.name, dataset.model.version)
     metadata = await search_provider.get_index_metadata(index)
     assert metadata.get("last_export") == dataset.model.last_export.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_reindex_with_new_last_export_updates_gauge(
+    zala_with_last_export,
+    search_provider: SearchProvider,
+):
+    """After re-loading the catalog with a newer `last_export`, the indexer
+    creates a fresh index (the version is derived from `last_export`) and the
+    gauge moves to the new timestamp."""
+    # First load (via the fixture) — gauge should reflect the initial export.
+    initial_values = _gauge_values_by_dataset("indexed_dataset_version_time")
+    assert initial_values.get("zala") == int(
+        datetime.fromisoformat(INITIAL_LAST_EXPORT_ISO).timestamp()
+    )
+
+    # Re-load the catalog with a bumped last_export and re-index.
+    async with patch_yente_catalog(ZALA_WITH_UPDATED_LAST_EXPORT_MANIFEST):
+        await update_index()
+
+    updated_values = _gauge_values_by_dataset("indexed_dataset_version_time")
+    assert updated_values.get("zala") == int(
+        datetime.fromisoformat(UPDATED_LAST_EXPORT_ISO).timestamp()
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_dataset_version_metric_missing_metadata(
+    search_provider: SearchProvider,
+):
+    """When the index has no `last_export` in `_meta`, no gauge value should be
+    emitted for the dataset (the function logs a warning and returns)."""
+    temp_index = settings.INDEX_NAME + "-metric-missing-meta"
+    await search_provider.create_index(
+        temp_index, mappings=make_entity_mapping(), settings=INDEX_SETTINGS
+    )
+    try:
+        await update_dataset_version_metric(
+            "dataset-with-no-meta", temp_index, search_provider
+        )
+        values = _gauge_values_by_dataset("indexed_dataset_version_time")
+        assert "dataset-with-no-meta" not in values
+    finally:
+        await search_provider.delete_index(temp_index)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,49 @@
+import pytest
+import pytest_asyncio
+
+from yente import settings
+from yente.data import get_catalog
+from yente.data.manifest import Manifest
+from yente.provider import SearchProvider
+from yente.search.indexer import update_index
+from yente.search.versions import build_index_name
+
+from tests.conftest import (
+    PARTEISPENDEN_MANIFEST,
+    build_index_alias_name_for_fixture,
+    patch_yente_catalog,
+)
+
+
+LAST_EXPORT_ISO = "2026-05-15T12:34:56"
+
+_manifest_dict = PARTEISPENDEN_MANIFEST.model_dump(mode="json")
+_manifest_dict["datasets"][0]["last_export"] = LAST_EXPORT_ISO
+PARTEISPENDEN_WITH_LAST_EXPORT_MANIFEST = Manifest.model_validate(_manifest_dict)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def parteispenden_with_last_export(monkeypatch):
+    monkeypatch.setattr(
+        settings,
+        "ENTITY_INDEX",
+        build_index_alias_name_for_fixture("parteispenden-last-export"),
+    )
+    async with patch_yente_catalog(PARTEISPENDEN_WITH_LAST_EXPORT_MANIFEST):
+        await update_index()
+        yield
+
+
+@pytest.mark.asyncio
+async def test_index_entities_writes_last_export_to_metadata(
+    parteispenden_with_last_export,
+    search_provider: SearchProvider,
+):
+    """index_entities should write dataset.model.last_export into the index
+    `_meta` so it survives the load and can be read back."""
+    catalog = await get_catalog()
+    dataset = catalog.require("parteispenden")
+    assert dataset.model.version is not None
+    index = build_index_name(dataset.name, dataset.model.version)
+    metadata = await search_provider.get_index_metadata(index)
+    assert metadata.get("last_export") == dataset.model.last_export.isoformat()

--- a/tests/test_search_provider.py
+++ b/tests/test_search_provider.py
@@ -153,10 +153,67 @@ async def test_clone_index_failure_restores_read_only(search_provider: SearchPro
     index_settings = resp[source]["settings"]["index"]
     blocks = index_settings.get("blocks", {})
     read_only = blocks.get("read_only", "false")
-    assert (
-        str(read_only).lower() != "true"
-    ), f"Source index is still read-only after failed clone: {read_only}"
+    assert str(read_only).lower() != "true", (
+        f"Source index is still read-only after failed clone: {read_only}"
+    )
 
     # Clean up
     await search_provider.delete_index(source)
     await search_provider.delete_index(target)
+
+
+@pytest.mark.asyncio
+async def test_index_metadata_roundtrip(search_provider: SearchProvider):
+    temp_index = settings.ENTITY_INDEX + "-meta-test"
+    await search_provider.create_index(
+        temp_index, mappings=TEST_MAPPINGS, settings=TEST_SETTINGS
+    )
+    try:
+        # Fresh index has no metadata
+        assert await search_provider.get_index_metadata(temp_index) == {}
+
+        # Round-trip a multi-key metadata dict
+        meta_v1 = {"last_export": "2026-06-01T12:00:00", "other": "x"}
+        await search_provider.set_index_metadata(temp_index, meta_v1)
+        assert await search_provider.get_index_metadata(temp_index) == meta_v1
+
+        # Replace-not-merge: setting a smaller dict drops keys not in it
+        meta_v2 = {"last_export": "2026-06-02T12:00:00"}
+        await search_provider.set_index_metadata(temp_index, meta_v2)
+        assert await search_provider.get_index_metadata(temp_index) == meta_v2
+
+        # Clearing
+        await search_provider.set_index_metadata(temp_index, {})
+        assert await search_provider.get_index_metadata(temp_index) == {}
+    finally:
+        await search_provider.delete_index(temp_index)
+
+
+@pytest.mark.asyncio
+async def test_index_metadata_clone_inherits_then_overwrites(
+    search_provider: SearchProvider,
+):
+    """Cloning copies the source's _meta to the target. Our indexer relies on
+    set_index_metadata being able to overwrite that inherited value."""
+    source = settings.ENTITY_INDEX + "-meta-clone-src"
+    target = settings.ENTITY_INDEX + "-meta-clone-tgt"
+    await search_provider.create_index(
+        source, mappings=TEST_MAPPINGS, settings=TEST_SETTINGS
+    )
+    try:
+        await search_provider.set_index_metadata(source, {"last_export": "A"})
+        await search_provider.clone_index(source, target)
+        try:
+            # Pin the ES behavior we're relying on
+            assert await search_provider.get_index_metadata(target) == {
+                "last_export": "A"
+            }
+            # And our overwrite works on the cloned index
+            await search_provider.set_index_metadata(target, {"last_export": "B"})
+            assert await search_provider.get_index_metadata(target) == {
+                "last_export": "B"
+            }
+        finally:
+            await search_provider.delete_index(target)
+    finally:
+        await search_provider.delete_index(source)

--- a/yente/app.py
+++ b/yente/app.py
@@ -18,7 +18,8 @@ from yente.data import refresh_catalog
 from yente.data.entity import Entity
 from yente.routers.util import ENABLED_ALGORITHMS
 from yente.search.indexer import update_index_threaded
-from yente.provider import close_provider
+from yente.data.metrics import update_metrics
+from yente.provider import with_provider, close_provider
 from yente.middleware import (
     MaxURLLengthMiddleware,
     RequestLogMiddleware,
@@ -29,10 +30,15 @@ log = get_logger("yente")
 ExceptionHandler = Callable[[Request, Any], Coroutine[Any, Any, Response]]
 
 
-async def cron_task() -> None:
+async def refresh_catalog_cron_task() -> None:
     await refresh_catalog()
     if settings.AUTO_REINDEX:
         update_index_threaded()
+
+
+async def update_metrics_task() -> None:
+    async with with_provider() as provider:
+        await update_metrics(provider)
 
 
 async def warm_up() -> None:
@@ -41,6 +47,7 @@ async def warm_up() -> None:
     await refresh_catalog()
     if settings.AUTO_REINDEX:
         update_index_threaded()
+    await update_metrics_task()
 
     log.debug("Warming up matcher algorithms...")
     # This is the pragmatic and easy way to warm up the matcher algorithms. If anyone feels the call to
@@ -78,7 +85,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         crontab=settings.CRONTAB,
         auto_reindex=settings.AUTO_REINDEX,
     )
-    settings.CRON = aiocron.crontab(settings.CRONTAB, func=cron_task)
+    settings.CRON = aiocron.crontab(settings.CRONTAB, func=refresh_catalog_cron_task)
+    # Local handle keeps the cron alive for the lifetime of the lifespan context.
+    _metrics_cron = aiocron.crontab("* * * * *", func=update_metrics_task)
     yield
     await close_provider()
 

--- a/yente/data/metrics.py
+++ b/yente/data/metrics.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timezone
+
+from opentelemetry import metrics
+
+from yente import settings
+from yente.logs import get_logger
+from yente.provider.base import SearchProvider
+from yente.search.versions import parse_index_name
+
+log = get_logger(__name__)
+
+_meter = metrics.get_meter("yente.data")
+_indexed_dataset_version_time = _meter.create_gauge(
+    "indexed_dataset_version_time",
+    unit="s",
+    description="Unix timestamp of the dataset's last_export for each indexed dataset",
+)
+
+
+async def update_dataset_version_metric(
+    dataset_name: str,
+    index: str,
+    provider: SearchProvider,
+) -> None:
+    metadata = await provider.get_index_metadata(index)
+    last_export = metadata.get("last_export")
+    if last_export is None:
+        log.warning(
+            "No last_export in index metadata", dataset=dataset_name, index=index
+        )
+        return
+    try:
+        dt = datetime.fromisoformat(last_export)
+    except (TypeError, ValueError):
+        log.warning(
+            "Could not parse last_export from index metadata",
+            dataset=dataset_name,
+            index=index,
+            last_export=last_export,
+        )
+        return
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    timestamp_s = int(dt.timestamp())
+    _indexed_dataset_version_time.set(timestamp_s, {"dataset": dataset_name})
+
+
+async def update_metrics(provider: SearchProvider) -> None:
+    """Refresh all dataset-level metrics by reading them from each currently
+    aliased index. Run on a cron so the gauges stay populated independently of
+    the reindex flow (which only fires when AUTO_REINDEX is on and only updates
+    the metric for the dataset it just reindexed)."""
+    for aliased_index in await provider.get_alias_indices(settings.ENTITY_INDEX):
+        try:
+            index_info = parse_index_name(aliased_index)
+        except ValueError:
+            log.warn("Invalid index name: %s" % aliased_index)
+            continue
+        await update_dataset_version_metric(
+            index_info.dataset_name, aliased_index, provider
+        )

--- a/yente/provider/base.py
+++ b/yente/provider/base.py
@@ -2,8 +2,20 @@ from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Union
 
 
 class SearchProvider(object):
-
     async def close(self) -> None:
+        raise NotImplementedError
+
+    async def set_index_metadata(self, index: str, metadata: Dict[str, Any]) -> None:
+        """Replace the index-level metadata dict with `metadata`.
+
+        Note: this is a full replace, not a merge — any keys previously present
+        and not in `metadata` will be removed. Callers must pass the complete
+        desired metadata.
+        """
+        raise NotImplementedError
+
+    async def get_index_metadata(self, index: str) -> Dict[str, Any]:
+        """Return the index-level metadata dict, or an empty dict if none is set."""
         raise NotImplementedError
 
     async def refresh(self, index: str) -> None:

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -179,10 +179,8 @@ class ElasticSearchProvider(SearchProvider):
     async def get_index_metadata(self, index: str) -> Dict[str, Any]:
         try:
             response = await self.client().indices.get_mapping(index=index)
-        except NotFoundError as nf:
-            raise YenteIndexError(f"Could not get index metadata: {nf}") from nf
-        except (ApiError, TransportError) as te:
-            raise YenteIndexError(f"Could not get index metadata: {te}") from te
+        except (NotFoundError, ApiError, TransportError) as exc:
+            raise YenteIndexError(f"Could not get index metadata: {exc}") from exc
         body = response.body if hasattr(response, "body") else response
         index_block = body.get(index, {})
         mappings = index_block.get("mappings", {})

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -168,6 +168,27 @@ class ElasticSearchProvider(SearchProvider):
         except (ApiError, TransportError) as te:
             raise YenteIndexError(f"Could not delete index: {te}") from te
 
+    async def set_index_metadata(self, index: str, metadata: Dict[str, Any]) -> None:
+        try:
+            await self.client().indices.put_mapping(
+                index=index, body={"_meta": metadata}
+            )
+        except (ApiError, TransportError) as te:
+            raise YenteIndexError(f"Could not set index metadata: {te}") from te
+
+    async def get_index_metadata(self, index: str) -> Dict[str, Any]:
+        try:
+            response = await self.client().indices.get_mapping(index=index)
+        except NotFoundError as nf:
+            raise YenteIndexError(f"Could not get index metadata: {nf}") from nf
+        except (ApiError, TransportError) as te:
+            raise YenteIndexError(f"Could not get index metadata: {te}") from te
+        body = response.body if hasattr(response, "body") else response
+        index_block = body.get(index, {})
+        mappings = index_block.get("mappings", {})
+        meta = mappings.get("_meta", {})
+        return cast(Dict[str, Any], meta)
+
     async def exists_index_alias(self, alias: str, index: str) -> bool:
         """Check if an index exists and is linked into the given alias."""
         try:

--- a/yente/provider/opensearch.py
+++ b/yente/provider/opensearch.py
@@ -213,6 +213,26 @@ class OpenSearchProvider(SearchProvider):
             raise YenteIndexError(f"Could not create index: {exc}") from exc
 
     @traced
+    async def set_index_metadata(self, index: str, metadata: Dict[str, Any]) -> None:
+        try:
+            await self.client.indices.put_mapping(index=index, body={"_meta": metadata})
+        except TransportError as te:
+            raise YenteIndexError(f"Could not set index metadata: {te}") from te
+
+    @traced
+    async def get_index_metadata(self, index: str) -> Dict[str, Any]:
+        try:
+            response = await self.client.indices.get_mapping(index=index)
+        except NotFoundError as nf:
+            raise YenteIndexError(f"Could not get index metadata: {nf}") from nf
+        except TransportError as te:
+            raise YenteIndexError(f"Could not get index metadata: {te}") from te
+        index_block = response.get(index, {})
+        mappings = index_block.get("mappings", {})
+        meta = mappings.get("_meta", {})
+        return cast(Dict[str, Any], meta)
+
+    @traced
     async def delete_index(self, index: str) -> None:
         """Delete a given index if it exists."""
         try:

--- a/yente/provider/opensearch.py
+++ b/yente/provider/opensearch.py
@@ -223,10 +223,8 @@ class OpenSearchProvider(SearchProvider):
     async def get_index_metadata(self, index: str) -> Dict[str, Any]:
         try:
             response = await self.client.indices.get_mapping(index=index)
-        except NotFoundError as nf:
-            raise YenteIndexError(f"Could not get index metadata: {nf}") from nf
-        except TransportError as te:
-            raise YenteIndexError(f"Could not get index metadata: {te}") from te
+        except (NotFoundError, TransportError) as exc:
+            raise YenteIndexError(f"Could not get index metadata: {exc}") from exc
         index_block = response.get(index, {})
         mappings = index_block.get("mappings", {})
         meta = mappings.get("_meta", {})

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -213,6 +213,17 @@ async def index_entities(
             next_index, mappings=make_entity_mapping(), settings=INDEX_SETTINGS
         )
 
+    # Always overwrite metadata: a fresh index has none, and a cloned index
+    # inherits the source's _meta (mappings can't be overridden in a clone request).
+    #
+    # Dates in ES documents would normally be stored as timestamps, but index
+    # metadata is just an opaque blob — ES doesn't parse or process it. For
+    # consistency we store values here exactly as we got them from the catalog.
+    index_metadata: Dict[str, Any] = {}
+    if dataset.model.last_export is not None:
+        index_metadata["last_export"] = dataset.model.last_export.isoformat()
+    await provider.set_index_metadata(next_index, index_metadata)
+
     try:
         docs = iter_entity_docs(updater, next_index)
 

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -39,6 +39,7 @@ from yente.search.versions import (
     get_system_version,
 )
 from yente.data.util import entity_weak_names, expand_dates, index_symbols
+from yente.data.metrics import update_dataset_version_metric
 
 
 log = get_logger(__name__)
@@ -213,17 +214,6 @@ async def index_entities(
             next_index, mappings=make_entity_mapping(), settings=INDEX_SETTINGS
         )
 
-    # Always overwrite metadata: a fresh index has none, and a cloned index
-    # inherits the source's _meta (mappings can't be overridden in a clone request).
-    #
-    # Dates in ES documents would normally be stored as timestamps, but index
-    # metadata is just an opaque blob — ES doesn't parse or process it. For
-    # consistency we store values here exactly as we got them from the catalog.
-    index_metadata: Dict[str, Any] = {}
-    if dataset.model.last_export is not None:
-        index_metadata["last_export"] = dataset.model.last_export.isoformat()
-    await provider.set_index_metadata(next_index, index_metadata)
-
     try:
         docs = iter_entity_docs(updater, next_index)
 
@@ -283,6 +273,17 @@ async def index_entities(
             )
         raise exc
 
+    # Always overwrite metadata: a fresh index has none, and a cloned index
+    # inherits the source's _meta (mappings can't be overridden in a clone request).
+    #
+    # Dates in ES documents would normally be stored as timestamps, but index
+    # metadata is just an opaque blob — ES doesn't parse or process it. For
+    # consistency we store values here exactly as we got them from the catalog.
+    index_metadata: Dict[str, Any] = {}
+    if dataset.model.last_export is not None:
+        index_metadata["last_export"] = dataset.model.last_export.isoformat()
+    await provider.set_index_metadata(next_index, index_metadata)
+
     await provider.refresh(index=next_index)
     dataset_prefix = build_index_name_prefix(dataset.name)
     # FIXME: we're not actually deleting old indexes here any more!
@@ -300,6 +301,10 @@ async def index_entities(
         message=f"Alias {alias} prefixed {dataset_prefix} now points to {next_index}",
     )
     log.info("Index is now aliased to: %s" % alias, index=next_index)
+    # Also refreshed periodically by update_metrics in a cron — calling it
+    # here just makes the gauge reflect a fresh reindex without waiting for
+    # the next cron tick.
+    await update_dataset_version_metric(dataset.name, next_index, provider)
 
 
 async def delete_old_indices(provider: SearchProvider, catalog: Catalog) -> None:


### PR DESCRIPTION
Adds an OpenTelemetry gauge `indexed_dataset_version_time` per dataset, exposing the dataset's `last_export` as a Unix timestamp. The value is written into the index's `_meta` mapping at index time and read back from there after each successful catalog refresh — so the metric reflects the actual export time of the data sitting in ES.

A small `SearchProvider` abstraction (`set_index_metadata` / `get_index_metadata`) handles the `_meta` read/write, with replace-not-merge semantics. Cloned (incremental-reindex) indexes inherit `_meta` from the source, so we overwrite unconditionally after clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)