### PR TITLE
search: index compound name tokens to match names with omitted spaces

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -202,6 +202,25 @@ def test_id_pass_through():
     assert res["query"]["id"] == "rotenberg"
 
 
+def test_match_name_without_spaces():
+    # A name query with spaces omitted ("vladimirovichputin") is a single token to the query
+    # analyzer, so ES fuzziness can't bridge the gap to the separate indexed tokens. We
+    # solve this at index time by also indexing compound tokens for adjacent name parts,
+    # and this test verifies that.
+    # The test also shows a limitation of our approach: the eu_fsf dataset only contains
+    # the full name "Vladimir Vladimirovich Putin", so we can't match "vladimirputin"
+    query = {
+        "queries": {
+            "a": {"schema": "Person", "properties": {"name": ["vladimirovichputin"]}}
+        }
+    }
+    resp = client.post("/match/default", json=query)
+    assert resp.status_code == 200, resp.text
+    res = resp.json()["responses"]["a"]
+    assert len(res["results"]) > 0, res
+    assert res["results"][0]["id"] == "Q7747", res["results"][0]
+
+
 def test_fuzzy_names():
     """Test that fuzzy retrieval from the index works."""
     query = {

--- a/yente/search/mapping.py
+++ b/yente/search/mapping.py
@@ -24,11 +24,33 @@ INDEX_SETTINGS = {
                 "filter": ["lowercase", "asciifolding"],
             }
         },
+        "filter": {
+            # Concatenates adjacent name tokens with no separator to produce compound tokens.
+            # "Vladimir Putin" → ["vladimir", "putin", "vladimirputin"]
+            # This allows queries where the space between adjacent name parts is omitted
+            # (e.g. "vladimirputin") to match the compound token at index time.
+            "name-token-concat": {
+                "type": "shingle",
+                "min_shingle_size": 2,
+                # Raising this to 3 would also handle three-part names with omitted spaces
+                # (e.g. "vladimirputinovanov"), at the cost of a larger index.
+                "max_shingle_size": 2,
+                "output_unigrams": True,
+                "token_separator": "",
+            },
+        },
         "analyzer": {
             "osa-analyzer": {
                 "tokenizer": "standard",
                 "filter": ["lowercase", "asciifolding"],
-            }
+            },
+            # Index-time only: emits compound tokens for adjacent name parts in addition
+            # to unigrams. Used as analyzer on NAMES_FIELD; osa-analyzer is used as
+            # search_analyzer so query-time analysis is not affected.
+            "osa-names-index-analyzer": {
+                "tokenizer": "standard",
+                "filter": ["lowercase", "asciifolding", "name-token-concat"],
+            },
         },
     },
     "index": {
@@ -175,6 +197,10 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
     # Weaker length normalization for names. Merged entities have a lot of names,
     # and we don't want to penalize them for that.
     mapping[NAMES_FIELD]["similarity"] = "weak_length_norm"
+    # Use osa-names-index-analyzer at index time to emit compound tokens for adjacent name
+    # parts (see name-token-concat filter above), and plain osa-analyzer at query time.
+    mapping[NAMES_FIELD]["analyzer"] = "osa-names-index-analyzer"
+    mapping[NAMES_FIELD]["search_analyzer"] = "osa-analyzer"
 
     # These fields will be pruned from the _source field after the document has been
     # indexed, but before the _source field is stored. We can still search on these fields,


### PR DESCRIPTION
## Summary

A query like "vladimirputin" (no space) arrives as a single token to the Elasticsearch analyzer. Fuzziness only applies within individual tokens, so it can't bridge the gap to the two indexed tokens "vladimir" + "putin" — the edit distance is just too large.

The fix: add an index-time shingle filter (`name-token-concat`) with an empty token separator to `osa-names-index-analyzer`. So "Vladimir Putin" gets indexed as `["vladimir", "putin", "vladimirputin"]`, and a query for "vladimirputin" finds the compound token directly.

We use a separate `search_analyzer` (plain `osa-analyzer`) so that query-time analysis is unaffected — otherwise a normal "Vladimir Putin" query would also generate a "vladimirputin" token that must be present, breaking matches against names like "Vladimir Vladimirovich Putin".

`max_shingle_size` is set to 2 (two-part concatenations). Raising to 3 would also cover three-part names at the cost of a larger index.

Requires a re-index to take effect.

## Known weakness

This only bridges *adjacent* indexed tokens. If a query both omits spaces *and* skips a middle name part — e.g. "vladimirputin" against an indexed "Vladimir Vladimirovich Putin" — we still can't match, because no shingle of size 2 over the indexed tokens produces "vladimirputin". The test `test_match_name_without_spaces` had to use "vladimirovichputin" instead (two adjacent tokens in the eu_fsf dataset entry) to exercise the fix.

Raising `max_shingle_size` doesn't fully solve this either — it would help for full omissions across N adjacent parts, but not arbitrary skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)