### PR TITLE
Index concatenated names as a keyword field

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -202,6 +202,29 @@ def test_id_pass_through():
     assert res["query"]["id"] == "rotenberg"
 
 
+def test_match_name_without_spaces():
+    # A name query with spaces omitted is a single token to the query
+    # analyzer, so ES fuzziness can't bridge the gap to the separate indexed tokens. We
+    # solve this at index time by also indexing compound tokens for adjacent name parts,
+    # and this test verifies that.
+    # The test also shows a limitation of our approach: the eu_fsf dataset only contains
+    # the full name "Vladimir Vladimirovich Putin", so we can't match "vladimirputin"
+    # (for now)
+    query = {
+        "queries": {
+            "a": {
+                "schema": "Person",
+                "properties": {"name": ["vladimirvladimirovichputin"]},
+            }
+        }
+    }
+    resp = client.post("/match/default", json=query)
+    assert resp.status_code == 200, resp.text
+    res = resp.json()["responses"]["a"]
+    assert len(res["results"]) > 0, res
+    assert res["results"][0]["id"] == "Q7747", res["results"][0]
+
+
 def test_fuzzy_names():
     """Test that fuzzy retrieval from the index works."""
     query = {

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncGenerator, AsyncIterable, Dict, List, Set
 from followthemoney import registry
 from followthemoney.exc import FollowTheMoneyException
 from followthemoney.names import entity_names
+from rigour.names import Name
 
 from yente import settings
 from yente.data.manifest import Catalog
@@ -26,6 +27,7 @@ from yente.search.mapping import (
     NAME_PART_FIELD,
     NAME_PHONETIC_FIELD,
     NAME_SYMBOLS_FIELD,
+    NAME_VARIANTS_FIELD,
     make_entity_mapping,
     INDEX_SETTINGS,
 )
@@ -87,6 +89,12 @@ async def iter_entity_docs(
     )
 
 
+def build_name_variants(name: Name) -> Set[str]:
+    # "vladimir putin" -> "valdimirputin"
+    # Normal Elastic fuzzy matching doesn't catch this because fuzzyness is per-token
+    return set(["".join([p.comparable for p in name.parts])])
+
+
 def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     doc = entity.to_dict(matchable=True)
     entity_id = doc.pop("id")
@@ -99,7 +107,10 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     name_parts: Set[str] = set()
     name_phonemes: Set[str] = set()
     name_symbols: Set[str] = set()
+    name_variants: Set[str] = set()
     for name in entity_names(entity, infer_initials=False):
+        name_variants.update(build_name_variants(name))
+
         name_symbols.update(index_symbols(name.symbols))
         for part in name.parts:
             name_parts.add(part.comparable)
@@ -113,6 +124,7 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     doc[NAME_PART_FIELD] = list(name_parts)
     doc[NAME_PHONETIC_FIELD] = list(name_phonemes)
     doc[NAME_SYMBOLS_FIELD] = list(name_symbols)
+    doc[NAME_VARIANTS_FIELD] = list(name_variants)
     if registry.date.group is not None:
         doc[registry.date.group] = expand_dates(doc.pop(registry.date.group, []))
     doc["text"] = entity.pop("indexText")

--- a/yente/search/mapping.py
+++ b/yente/search/mapping.py
@@ -61,6 +61,7 @@ NAMES_FIELD = NameType.group or "names"
 NAME_PART_FIELD = "name_parts"
 NAME_SYMBOLS_FIELD = "name_symbols"
 NAME_PHONETIC_FIELD = "name_phonetic"
+NAME_VARIANTS_FIELD = "name_variants"
 
 
 def make_field(
@@ -157,7 +158,7 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
         "entity_values_count": make_field("integer"),
         NAME_PHONETIC_FIELD: make_keyword(),
         NAME_PART_FIELD: make_field("keyword", copy_to=["text"]),
-        # NAME_KEY_FIELD: make_field("keyword"),
+        NAME_VARIANTS_FIELD: make_field("keyword"),
         NAME_SYMBOLS_FIELD: make_field("keyword"),
         "last_change": make_field("date", format=DATE_FORMAT),
         "last_seen": make_field("date", format=DATE_FORMAT),
@@ -183,7 +184,7 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
     drop_fields.append("text")
     drop_fields.append(NAME_PHONETIC_FIELD)
     drop_fields.append(NAME_PART_FIELD)
-    # drop_fields.append(NAME_KEY_FIELD)
+    drop_fields.append(NAME_VARIANTS_FIELD)
     drop_fields.append(NAME_SYMBOLS_FIELD)
     drop_fields.remove(NAMES_FIELD)
     return {

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -14,7 +14,8 @@ from yente import settings
 from yente.logs import get_logger
 from yente.data.dataset import Dataset
 from yente.data.util import entity_weak_names, index_symbols
-from yente.search.mapping import NAME_SYMBOLS_FIELD, NAMES_FIELD
+from yente.search.indexer import build_name_variants
+from yente.search.mapping import NAME_SYMBOLS_FIELD, NAME_VARIANTS_FIELD, NAMES_FIELD
 from yente.search.mapping import NAME_PART_FIELD, NAME_PHONETIC_FIELD
 
 log = get_logger(__name__)
@@ -60,8 +61,8 @@ def tq(field: str, value: str | bool, boost: float = 1.0) -> Clause:
     return {"term": {field: {"value": value, "boost": boost}}}
 
 
-def tqs(field: str, values: Iterable[str | bool | float]) -> Clause:
-    return {"terms": {field: list(values)}}
+def tqs(field: str, values: Iterable[str | bool | float], boost: float = 1.0) -> Clause:
+    return {"terms": {field: list(values), "boost": boost}}
 
 
 def filter_query(
@@ -153,6 +154,12 @@ def names_query(entity: EntityProxy) -> List[Clause]:
 
     seen: Set[str] = set()
     for name in Name.consolidate_names(name_objs):
+        # Name variants are keyword renditions of common name variations that people expect to
+        # match but that the ES fuzzyness does not catch.
+        # Example: "vladimirputin" (without a space) does not get matched by the per-token fuzzyness
+        name_variants = build_name_variants(name)
+        shoulds.append(tqs(NAME_VARIANTS_FIELD, name_variants, boost=2))
+
         part_symbols: Dict[NamePart, Set[Symbol]] = defaultdict(set)
         for span in name.spans:
             for part in span.parts:

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -1,4 +1,5 @@
 import enum
+import itertools
 from pprint import pprint  # noqa
 from rigour.names import Name, NamePart, Symbol, representative_names
 from collections import defaultdict
@@ -153,13 +154,19 @@ def names_query(entity: EntityProxy) -> List[Clause]:
         shoulds.append({"match": match})
 
     seen: Set[str] = set()
-    for name in Name.consolidate_names(name_objs):
-        # Name variants are keyword renditions of common name variations that people expect to
-        # match but that the ES fuzzyness does not catch.
-        # Example: "vladimirputin" (without a space) does not get matched by the per-token fuzzyness
-        name_variants = build_name_variants(name)
-        shoulds.append(tqs(NAME_VARIANTS_FIELD, name_variants, boost=2))
+    consolidated_names = Name.consolidate_names(name_objs)
 
+    # Name variants are keyword renditions of common name variations that people expect to
+    # match but that the ES fuzzyness does not catch.
+    # Example: "vladimirputin" (without a space) does not get matched by the per-token fuzzyness
+    name_variants = set(
+        itertools.chain.from_iterable(
+            build_name_variants(name) for name in consolidated_names
+        )
+    )
+    shoulds.append(tqs(NAME_VARIANTS_FIELD, name_variants, boost=2))
+
+    for name in consolidated_names:
         part_symbols: Dict[NamePart, Set[Symbol]] = defaultdict(set)
         for span in name.spans:
             for part in span.parts:


### PR DESCRIPTION
When a user queries a name with the spaces omitted (eg. "vladimirputin"), ES sees a single token and the per-token fuzziness can't bridge the gap to the separate indexed tokens ("vladimir", "putin"). So we miss matches that a human would consider obvious.

Follow-up to #1136 based on @pudo's suggestion: instead of running the expensive fuzzy matching on an extra synthetic concatenated name, generate a keyword `name_variants` field at index time and query it exactly with the same transposer.

Right now the only variant is "concatenated name parts" (so "vladimir putin" -> "vladimirputin"), but the structure leaves room for other transpositions later (eg. sorted tokens) without paying fuzzy cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)