### PR TITLE
search: fuzzy name match via SymSpell deletion neighborhood

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -204,30 +204,93 @@ def test_id_pass_through():
 
 def test_fuzzy_names():
     """Test that fuzzy retrieval from the index works."""
-    query = {
-        "queries": {"a": {"schema": "Person", "properties": {"name": "Viadimit Putln"}}}
-    }
 
+    # With MATCH_FUZZY off, even a single-character typo on any name token should
+    # prevent the entity from being retrieved.
     with mock.patch("yente.settings.MATCH_FUZZY", False):
-        # We need to set a lower threshold to get logic-v2 to score it high enough.
-        # That's okay, we care about testing the fuzzy retrieval from the index,
-        # not the details of the scoring algorithm.
-        resp = client.post(
-            "/match/default", json=query, params={"algorithm": "best", "threshold": 0.2}
-        )
-        data = resp.json()
-        res = data["responses"]["a"]
-        assert len(res["results"]) == 0, res
-
-    with mock.patch("yente.settings.MATCH_FUZZY", True):
-        # The result scores quite low, so we need to set a lower threshold to get a result
+        # Edit-1 typo on each token. Both tokens have to be typo'd, otherwise an
+        # exact match on the untouched token alone is enough to retrieve Putin
+        # even without fuzzy matching. The typos are also chosen so their
+        # metaphones (FLTMT, PTNK) differ from those of the original ("Vladimir",
+        # "Putin" → FLTMR, PTN), so the phonetic channel doesn't retrieve Putin
+        # either.
         resp = client.post(
             "/match/default",
-            params={"threshold": 0.2, "algorithm": "logic-v2"},
-            json=query,
+            json={
+                "queries": {
+                    "a": {
+                        "schema": "Person",
+                        "properties": {"name": "Vladimit Puting"},
+                    }
+                }
+            },
+            params={"algorithm": "best", "threshold": 0.2},
         )
-        data = resp.json()
-        res = data["responses"]["a"]
+        res = resp.json()["responses"]["a"]
+        assert len(res["results"]) == 0, res
+
+        # Edit-2 typos on both tokens, again chosen so the metaphones (FTMT, PFM)
+        # differ from the originals (FLTMR, PTN).
+        resp = client.post(
+            "/match/default",
+            json={
+                "queries": {
+                    "a": {
+                        "schema": "Person",
+                        "properties": {"name": "Viadimit Pufim"},
+                    }
+                }
+            },
+            params={"algorithm": "best", "threshold": 0.2},
+        )
+        res = resp.json()["responses"]["a"]
+        assert len(res["results"]) == 0, res
+
+    # With MATCH_FUZZY on, both queries should recover Putin. We're testing
+    # Elasticsearch retrieval here, not the logic-v2 scoring algorithm — the
+    # threshold is set low because logic-v2 penalizes typo'd inputs and the score
+    # is not what this test is about.
+    with mock.patch("yente.settings.MATCH_FUZZY", True):
+        # Edit-1 typo on each token. Both tokens have to be typo'd, otherwise an
+        # exact match on the untouched token alone is enough to retrieve Putin
+        # even without fuzzy matching. The typos are also chosen so their
+        # metaphones (FLTMT, PTNK) differ from those of the original ("Vladimir",
+        # "Putin" → FLTMR, PTN), so the phonetic channel doesn't retrieve Putin
+        # either.
+        resp = client.post(
+            "/match/default",
+            json={
+                "queries": {
+                    "a": {
+                        "schema": "Person",
+                        "properties": {"name": "Vladimit Puting"},
+                    }
+                }
+            },
+            params={"algorithm": "logic-v2", "threshold": 0.2},
+        )
+        res = resp.json()["responses"]["a"]
+        assert len(res["results"]) > 0, res
+        assert res["results"][0]["id"] == "Q7747", res["results"][0]
+
+        # Edit-2 typos on both tokens, again chosen so the metaphones (FTMT, PFM)
+        # differ from the originals (FLTMR, PTN). EXPECTED TO FAIL: the
+        # NAME_PART_FUZZY_FIELD deletion neighborhood is generated at depth 1, so
+        # only edit-distance-1 token typos are recovered. Extending the deletion
+        # depth to 2 would make this case pass.
+        resp = client.post(
+            "/match/default",
+            json={
+                "queries": {
+                    "a": {
+                        "schema": "Person",
+                        "properties": {"name": "Viadimit Pufim"},
+                    }
+                }
+            },
+            params={"algorithm": "logic-v2", "threshold": 0.2},
+        )
+        res = resp.json()["responses"]["a"]
         assert len(res["results"]) > 0, res
         assert res["results"][0]["id"] == "Q7747", res["results"][0]
 

--- a/yente/data/util.py
+++ b/yente/data/util.py
@@ -37,6 +37,28 @@ def index_symbols(symbols: Set[Symbol]) -> Generator[str, None, None]:
             yield f"{symbol.category.value}:{symbol.id}"
 
 
+# Fuzzy matching for name tokens via a SymSpell-style deletion neighborhood: a
+# token's fuzzy keys are the token itself plus every string obtained by deleting
+# one character. Emitting the same set on both indexing and query side makes two
+# tokens match iff they are within edit distance 1 (transpositions included) — a
+# plain `terms` lookup with no per-query term-dictionary scan.
+NAME_PART_FUZZY_MIN_LENGTH = 4
+
+
+def name_part_fuzzy_keys(part: str) -> Set[str]:
+    """SymSpell deletion keys for a normalized name token.
+
+    Tokens shorter than NAME_PART_FUZZY_MIN_LENGTH return only the token itself —
+    their deletions are too short to be selective and would balloon posting lists.
+    """
+    result: Set[str] = {part}
+    if len(part) < NAME_PART_FUZZY_MIN_LENGTH:
+        return result
+    for i in range(len(part)):
+        result.add(part[:i] + part[i + 1 :])
+    return result
+
+
 @cache
 def _entity_weak_props(schema: Schema) -> Set[Property]:
     """Get the set of properties that are not used for matching but can be used for

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -24,6 +24,7 @@ from yente.search import audit_log
 from yente.search.audit_log import get_audit_log_index_name, AuditLogEventType
 from yente.search.mapping import (
     NAME_PART_FIELD,
+    NAME_PART_FUZZY_FIELD,
     NAME_PHONETIC_FIELD,
     NAME_SYMBOLS_FIELD,
     make_entity_mapping,
@@ -36,7 +37,12 @@ from yente.search.versions import (
     build_index_name,
     get_system_version,
 )
-from yente.data.util import entity_weak_names, expand_dates, index_symbols
+from yente.data.util import (
+    entity_weak_names,
+    expand_dates,
+    index_symbols,
+    name_part_fuzzy_keys,
+)
 
 
 log = get_logger(__name__)
@@ -110,7 +116,13 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     for weak in entity_weak_names(entity):
         name_parts.add(weak)
 
+    # Pre-compute fuzzy lookup keys per name token; see mapping.NAME_PART_FUZZY_FIELD.
+    name_part_fuzzy: Set[str] = set()
+    for part_str in name_parts:
+        name_part_fuzzy.update(name_part_fuzzy_keys(part_str))
+
     doc[NAME_PART_FIELD] = list(name_parts)
+    doc[NAME_PART_FUZZY_FIELD] = list(name_part_fuzzy)
     doc[NAME_PHONETIC_FIELD] = list(name_phonemes)
     doc[NAME_SYMBOLS_FIELD] = list(name_symbols)
     if registry.date.group is not None:

--- a/yente/search/mapping.py
+++ b/yente/search/mapping.py
@@ -59,6 +59,7 @@ INDEX_SETTINGS = {
 }
 NAMES_FIELD = NameType.group or "names"
 NAME_PART_FIELD = "name_parts"
+NAME_PART_FUZZY_FIELD = "name_parts_fuzzy"
 NAME_SYMBOLS_FIELD = "name_symbols"
 NAME_PHONETIC_FIELD = "name_phonetic"
 
@@ -157,6 +158,17 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
         "entity_values_count": make_field("integer"),
         NAME_PHONETIC_FIELD: make_keyword(),
         NAME_PART_FIELD: make_field("keyword", copy_to=["text"]),
+        # Fuzzy-match channel for name tokens. We trade index size and indexing
+        # time for cheap query-time fuzzy lookup: each token is expanded into a
+        # SymSpell deletion neighborhood (the token itself plus every string
+        # obtained by deleting one character) and stored here as keywords. The
+        # query side does the same expansion and runs a plain `terms` lookup,
+        # so fuzzy matching becomes inverted-index intersection rather than a
+        # term-dictionary scan. The expansion factor is roughly 1 + token_length,
+        # bounded and linear in token length. Recall can be extended to edit
+        # distance 2 in the future by deepening the deletion neighborhood, at a
+        # superlinear cost in keys per token.
+        NAME_PART_FUZZY_FIELD: make_keyword(),
         # NAME_KEY_FIELD: make_field("keyword"),
         NAME_SYMBOLS_FIELD: make_field("keyword"),
         "last_change": make_field("date", format=DATE_FORMAT),
@@ -183,6 +195,7 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
     drop_fields.append("text")
     drop_fields.append(NAME_PHONETIC_FIELD)
     drop_fields.append(NAME_PART_FIELD)
+    drop_fields.append(NAME_PART_FUZZY_FIELD)
     # drop_fields.append(NAME_KEY_FIELD)
     drop_fields.append(NAME_SYMBOLS_FIELD)
     drop_fields.remove(NAMES_FIELD)

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -13,9 +13,13 @@ from nomenklatura.matching.logic_v2.names.analysis import entity_names
 from yente import settings
 from yente.logs import get_logger
 from yente.data.dataset import Dataset
-from yente.data.util import entity_weak_names, index_symbols
+from yente.data.util import entity_weak_names, index_symbols, name_part_fuzzy_keys
 from yente.search.mapping import NAME_SYMBOLS_FIELD, NAMES_FIELD
-from yente.search.mapping import NAME_PART_FIELD, NAME_PHONETIC_FIELD
+from yente.search.mapping import (
+    NAME_PART_FIELD,
+    NAME_PART_FUZZY_FIELD,
+    NAME_PHONETIC_FIELD,
+)
 
 log = get_logger(__name__)
 Clause = Dict[str, Any]
@@ -135,11 +139,10 @@ def filter_query(
 def names_query(entity: EntityProxy) -> List[Clause]:
     names = entity.get_type_values(registry.name, matchable=True)
     name_objs = entity_names(entity, is_query=True)
-    # Single-word names are hard to match, so we use fuzzy matching more aggressively.
-    # FIXME: This could make sense for 2 part names as well?
-    is_short = max((len(n.parts) for n in name_objs), default=0) < 2
     shoulds: List[Clause] = []
     for picked_name in representative_names(names, 5):
+        # Exact phrase-like signal on the whole name. Per-token fuzzy recall is
+        # carried by NAME_PART_FUZZY_FIELD in the dis_max clauses below.
         match = {
             NAMES_FIELD: {
                 "query": picked_name,
@@ -147,8 +150,6 @@ def names_query(entity: EntityProxy) -> List[Clause]:
                 "boost": 3.0,
             }
         }
-        if settings.MATCH_FUZZY or is_short:
-            match[NAMES_FIELD]["fuzziness"] = "AUTO"
         shoulds.append({"match": match})
 
     seen: Set[str] = set()
@@ -179,6 +180,21 @@ def names_query(entity: EntityProxy) -> List[Clause]:
             # to this name part just because multiple variants match.
             query_variants: List[Clause] = []
             query_variants.append(tq(NAME_PART_FIELD, part.comparable))
+
+            # Fuzzy variant: emit the same SymSpell deletion keys as the indexer
+            # and look them up against NAME_PART_FUZZY_FIELD, giving edit-distance-1
+            # recall via a plain terms query.
+            if settings.MATCH_FUZZY:
+                fuzzy_keys = name_part_fuzzy_keys(part.comparable)
+                if len(fuzzy_keys) > 1:
+                    query_variants.append(
+                        {
+                            "terms": {
+                                NAME_PART_FUZZY_FIELD: list(fuzzy_keys),
+                                "boost": boost * 0.7,
+                            }
+                        }
+                    )
 
             metaphone = part.metaphone
             if metaphone is not None and len(metaphone) > 2:


### PR DESCRIPTION
## Summary

Profiling a `Vladimir Putin`-style `/match` query against the full production index showed that ~28 ms of the ~54 ms `took` was spent in `search.rewrite_time` — Lucene rewriting the `fuzziness: AUTO` clause on the `names` match by intersecting a Levenshtein automaton with the term dictionary FST. The cost scales with how wide the `names` term dictionary is (currently ~1.2M unique tokens in `name_parts`), which is exactly the direction we're growing.

This PR moves that cost from query time to index time:

- A new `name_parts_fuzzy` keyword field stores, for each normalized name token, the token itself plus every string obtained by deleting one character (SymSpell deletion neighborhood at depth δ=1).
- At query time, `names_query` generates the same expansion for each query token and looks it up with a plain `terms` query as an additional `dis_max` variant alongside the existing exact/phonetic/symbol channels.
- The `fuzziness: AUTO` clause on the `names` match is dropped — per-token fuzzy recall now lives in `name_parts_fuzzy`.

This makes fuzzy matching an inverted-index intersection instead of a per-shard term-dictionary scan, and the recall guarantee at edit-distance 1 (transpositions included) is provable per token rather than capped by Lucene's `max_expansions` top-N heuristic.

I haven't benchmarked this against the n-gram alternative below — the choice here is based on profile-driven reasoning about where the cost lives, not measured A/B. If we want to make a defensible choice we should index both into a side cluster and compare query cost and recall on real workloads.

## Alternatives

The Elastic-recommended way to do fuzzy name matching natively is **character n-grams**, e.g. trigrams. The idea: at index time, split each name into overlapping 3-character chunks — `Vladimir` becomes `vla`, `lad`, `adi`, `dim`, `imi`, `mir`. Store every chunk as a search key in the inverted index alongside the doc's other fields. At query time, do the same to the query string and find docs whose chunks overlap enough. Two strings that differ by a typo or two still share most of their chunks, so this gives you a soft "approximately the same name" recall channel. Elastic supports this directly via the `ngram` token filter and the standard analyzer chain.

This is a well-trodden recipe with real strengths: recall degrades gracefully with edit distance (a name with 3 typos still shares plenty of trigrams), and it naturally handles substring matches like `Vlad` ↔ `Vladimir` (both contain `vla` and `lad`). The downsides are practical:

**Big posting lists.** Elastic's inverted index works by, for each search key, storing the list of all doc IDs that contain it — that list is called a "posting list". When a query fires, Elastic walks the posting lists for the query's keys and finds the docs that show up enough times across them. Trigrams like `vla`, `dim`, `mir` appear in a huge fraction of names in the index, so their posting lists are tens or hundreds of thousands of doc IDs long. To answer a query for `Vladimir`, Elastic has to walk all six of those long lists and merge them. That's exactly the kind of `next_doc` work that already shows up as the dominant cost in our query profile (~9.75 ms on the main query). Trigrams would make that worse, not better.

**Threshold tuning.** You need to set `minimum_should_match` to decide how much overlap counts as "approximately the same name". Too low and the scorer drowns in candidates; too high and real matches drop off. There isn't one good value for all name lengths.

The deletion-neighborhood approach in this PR has the opposite shape: each key (like `vladimi` — `Vladimir` with one character missing) is very specific, so its posting list is tiny — only the few names that happen to delete to exactly that string. Walking it is cheap. The cost is that we get a hard cutoff at edit distance δ instead of graceful overlap, and we need a custom indexer step instead of letting Elastic's analyzer do it.

## Recall scope

Depth δ=1 covers all edit-distance-1 typos (sub/ins/del) and single transpositions, per token. Edit-distance 2 is **not** covered — there's a test case (`Viadimit Pufim`) documenting this gap. Extending to δ=2 widens recall at the cost of more keys per token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)