### PR TITLE
match: retrieve & score at most MAX_MATCH_CANDIDATES (default: 500)

### DIFF
--- a/yente/routers/match.py
+++ b/yente/routers/match.py
@@ -241,7 +241,12 @@ async def match(
     # get a broad range of candidates to score against. This is a trade-off
     # between speed and accuracy.
     candidates = limit * settings.MATCH_CANDIDATES
+    # We want at least 20 candidates to score to have good results even for limit = 1
     candidates = max(20, min(settings.MAX_RESULTS, candidates))
+    # We want to retrieve at most MAX_MATCH_CANDIDATES, other wise we will be
+    # very slow or OOM for high values of limit.
+    # One day we might drop the max for limit, see https://github.com/opensanctions/yente/issues/927
+    candidates = min(candidates, settings.MAX_MATCH_CANDIDATES)
     # This is more of a formality - candidates will never be >= 10000 (settings.MAX_RESULTS)
     candidates, _ = limit_window(candidates, 0)
 

--- a/yente/routers/match.py
+++ b/yente/routers/match.py
@@ -245,8 +245,9 @@ async def match(
     candidates = max(20, min(settings.MAX_RESULTS, candidates))
     # We want to retrieve at most MAX_MATCH_CANDIDATES, other wise we will be
     # very slow or OOM for high values of limit.
+    # But at least `limit` candidates, otherwise we'll run out of results to return.
     # One day we might drop the max for limit, see https://github.com/opensanctions/yente/issues/927
-    candidates = min(candidates, settings.MAX_MATCH_CANDIDATES)
+    candidates = min(candidates, max(settings.MAX_MATCH_CANDIDATES, limit))
     # This is more of a formality - candidates will never be >= 10000 (settings.MAX_RESULTS)
     candidates, _ = limit_window(candidates, 0)
 

--- a/yente/routers/reconcile.py
+++ b/yente/routers/reconcile.py
@@ -253,7 +253,15 @@ async def reconcile_query(
         es_query = entity_query(dataset, proxy, changed_since=changed_since)
     except Exception as exc:
         raise HTTPException(400, detail=str(exc))
+
     candidates = query.limit * settings.MATCH_CANDIDATES
+    # We want at least 20 candidates to score to have good results even for limit = 1
+    candidates = max(20, min(settings.MAX_RESULTS, candidates))
+    # We want to retrieve at most MAX_MATCH_CANDIDATES, other wise we will be
+    # very slow or OOM for high values of limit.
+    # One day we might drop the max for limit, see https://github.com/opensanctions/yente/issues/927
+    candidates = min(candidates, settings.MAX_MATCH_CANDIDATES)
+
     candidates, offset = limit_window(candidates, 0)
     resp = await search_entities(provider, es_query, limit=candidates, offset=offset)
     algorithm_ = get_algorithm_by_name(algorithm)

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -166,6 +166,10 @@ MAX_MATCHES = env_int("YENTE_MAX_MATCHES", 500)
 # How many candidates to retrieve as a multiplier of the /match limit:
 MATCH_CANDIDATES = env_int("YENTE_MATCH_CANDIDATES", 10)
 
+# How many candidates to retrieve & score at most
+# Used so that limit * MATCH_CANDIDATES doesn't get out of hand for high values of limit
+MAX_MATCH_CANDIDATES = env_int("YENTE_MAX_MATCH_CANDIDATES", 500)
+
 # Whether to run expensive levenshtein queries inside ElasticSearch:
 MATCH_FUZZY = as_bool(env_str("YENTE_MATCH_FUZZY", "true"))
 


### PR DESCRIPTION
This prevents slow responses and OOMs for high values of `limit`.

Open question: do we want to set the default to very high and only modify this in our prod deployment?