### PR TITLE
Reject oversized request URLs with HTTP 414

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,3 +34,19 @@ def test_match_without_content_type_header():
     res = client.post("/match/default", content=json.dumps(query))
     # Not 422 Unprocessable Entity
     assert res.status_code == 200, res.json()
+
+
+def test_max_url_length_rejects_oversized_query():
+    """A URL above the cap is rejected with 414 before it can reach a handler."""
+    long_q = "a" * (settings.MAX_URL_LENGTH + 100)
+    res = client.get(f"/search/default?q={long_q}")
+    assert res.status_code == 414, res.text
+    assert res.json() == {"detail": "Request URI too long"}
+
+
+def test_max_url_length_allows_normal_query():
+    """A regular query string is unaffected by the middleware."""
+    res = client.get("/search/default?q=acme")
+    # 200 if the index is populated, 503 if it isn't — either confirms the
+    # request reached the search handler rather than being short-circuited.
+    assert res.status_code in (200, 503), res.text

--- a/yente/app.py
+++ b/yente/app.py
@@ -19,7 +19,11 @@ from yente.data.entity import Entity
 from yente.routers.util import ENABLED_ALGORITHMS
 from yente.search.indexer import update_index_threaded
 from yente.provider import close_provider
-from yente.middleware import RequestLogMiddleware, TraceContextMiddleware
+from yente.middleware import (
+    MaxURLLengthMiddleware,
+    RequestLogMiddleware,
+    TraceContextMiddleware,
+)
 
 log = get_logger("yente")
 ExceptionHandler = Callable[[Request, Any], Coroutine[Any, Any, Response]]
@@ -140,6 +144,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.add_middleware(GZipMiddleware, minimum_size=500)
+    app.add_middleware(MaxURLLengthMiddleware)
     app.include_router(match.router)
     app.include_router(search.router)
     app.include_router(reconcile.router)

--- a/yente/middleware/__init__.py
+++ b/yente/middleware/__init__.py
@@ -1,4 +1,10 @@
+from .max_url_length import MaxURLLengthMiddleware
 from .request_log import RequestLogMiddleware
 from .trace_context import TraceContextMiddleware
 
-__all__ = ["RequestLogMiddleware", "TraceContextMiddleware", "get_trace_context"]
+__all__ = [
+    "MaxURLLengthMiddleware",
+    "RequestLogMiddleware",
+    "TraceContextMiddleware",
+    "get_trace_context",
+]

--- a/yente/middleware/max_url_length.py
+++ b/yente/middleware/max_url_length.py
@@ -1,0 +1,39 @@
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from yente import settings
+from yente.logs import get_logger
+
+log = get_logger(__name__)
+
+
+class MaxURLLengthMiddleware:
+    """Reject requests whose URL exceeds ``settings.MAX_URL_LENGTH`` with HTTP 414.
+
+    Defends against an upstream parser bug (``httptools.parse_url`` wraps at
+    65 536 bytes and silently truncates the path/query) by capping URL length
+    below the wrap point so a client error is returned instead of data loss.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            raw_path = scope.get("raw_path") or scope["path"].encode()
+            query_string = scope.get("query_string", b"")
+            url_len = len(raw_path) + len(query_string) + (1 if query_string else 0)
+            if url_len > settings.MAX_URL_LENGTH:
+                log.warn(
+                    "Request URI too long",
+                    url_length=url_len,
+                    limit=settings.MAX_URL_LENGTH,
+                    path=scope["path"][:200],
+                )
+                response = JSONResponse(
+                    status_code=414,
+                    content={"detail": "Request URI too long"},
+                )
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)

--- a/yente/middleware/max_url_length.py
+++ b/yente/middleware/max_url_length.py
@@ -13,6 +13,11 @@ class MaxURLLengthMiddleware:
     Defends against an upstream parser bug (``httptools.parse_url`` wraps at
     65 536 bytes and silently truncates the path/query) by capping URL length
     below the wrap point so a client error is returned instead of data loss.
+
+    We handle this at the application layer because yente uses uvicorn by default
+    and even though it would be better to handle this at the HTTP paser layer,
+    we want to provide a safe default that errors instead of silently altering
+    the meaning of the request.
     """
 
     def __init__(self, app: ASGIApp) -> None:

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -157,6 +157,11 @@ MAX_BATCH = int(env_str("YENTE_MAX_BATCH", "100"))
 MAX_RESULTS = 9999
 MAX_OFFSET = MAX_RESULTS - MAX_PAGE
 
+# Maximum length of an incoming request URL (path + query string), in bytes.
+# Sits below httptools' 65 536-byte wrap-around so we reject with 414 before
+# the parser silently truncates.
+MAX_URL_LENGTH = env_int("YENTE_MAX_URL_LENGTH", 60000)
+
 # How many results to return per /match query by default:
 MATCH_PAGE = env_int("YENTE_MATCH_PAGE", 5)
 


### PR DESCRIPTION
## Summary

- Adds `MaxURLLengthMiddleware` (pure ASGI) that rejects requests whose URL (`raw_path` + `query_string`) exceeds `YENTE_MAX_URL_LENGTH` (default **60 000** bytes) with a 414 `Request URI too long` JSON response.
- Sits as the outermost middleware in `create_app()` so it short-circuits before request logging, CORS, GZip, or any handler runs.
- Adds two tests in `tests/test_app.py` exercising the reject and pass paths.

Fixes #1065.

## Why

yente clients have been observed silently losing GET parameters when sending very long query strings. Root cause: yente runs `uvicorn[standard]`, which selects the **httptools** parser. After streaming-parsing the request line, uvicorn calls `httptools.parse_url(self.url)` (see `httptools_impl.py:~255`). That function has a 16-bit overflow ([MagicStack/httptools#43](https://github.com/MagicStack/httptools/issues/43)) — URLs ≥ 65 536 bytes have their `path` and `query` components silently truncated, and uvicorn then writes the mangled bytes into the ASGI scope as if everything were fine. The httptools issue has been open and unfixed since 2019.

We can't fix the parser, so the middleware caps URL length below the wrap so legitimate-but-long requests (yente clients legitimately send tens-of-KB filter expressions) still go through, while pathological lengths produce a clear client error.

## Caveat (documented for follow-up)

By the time the middleware runs, `scope["raw_path"]`/`scope["query_string"]` are already the post-truncation bytes — uvicorn doesn't surface the original URL anywhere in scope. So the middleware is a **preventive** cap, not a **detective** one:

| Wire URL size | scope shows… | Verdict at cap = 60 000 |
|---|---|---|
| ≤ 60 000 | full URL | passes |
| 60 001 – 65 535 | full URL | rejected with 414 |
| 65 536 – 125 536 | tiny truncated remainder | passes (gap) |
| 125 537+ | larger truncated remainder | rejected with 414 |

The 65 536–125 536 gap requires a deliberately crafted URL (no client hits this by accident). Closing it fully needs either a uvicorn protocol subclass that checks `len(self.url)` before `parse_url` runs, or switching to the `h11` parser (loses httptools performance). Worth a follow-up, but not blocking for #1065's stated requirement of "return a client error, don't silently eat data."

## Test plan

- [x] `pytest tests/test_app.py` — all 4 tests green (incl. 2 new)
- [x] Live curl against a running yente:
  - `curl -o /dev/null -w "%{http_code}\n" "http://localhost:8000/search/default?q=$(python -c 'print("a"*65000)')"` → expect **414**
  - `curl -o /dev/null -w "%{http_code}\n" "http://localhost:8000/search/default?q=$(python -c 'print("a"*40000)')"` → expect **200** (or 503 if no index yet)
- [ ] Confirm `YENTE_MAX_URL_LENGTH` env override is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)