### PR TITLE
test: drop live-catalog dependency from test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,8 @@ EU_FSF_MANIFEST = Manifest.model_validate(
                 "resource_name": "entities.ftm.json",
             }
         ],
+        # parteispenden is included as a local dataset alongside the remote
+        # catalog so tests can exercise the "catalog + local dataset" mix.
         "datasets": [
             {
                 "name": "parteispenden",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,12 @@
 #
 #   - zala_test_dataset:          small local sanctions cluster (Zakharov + Zala Aero)
 #   - parteispenden_test_dataset: small local dataset of German political donations
-#   - live_catalog_eu_fsf:        real eu_fsf catalog, fetched live from data.opensanctions.org
+#
+# For tests that exercise something very specific (a particular catalog shape,
+# scoping behaviour, etc.), prefer building a custom minimal manifest inline
+# in the test instead of adding a new shared fixture. This keeps each test
+# unit-testy (one thing under test), reduces fixture sprawl, and avoids
+# cross-test coupling. See test_catalog in tests/test_base.py for an example.
 import re
 import pytest_asyncio
 from datetime import datetime
@@ -81,44 +86,6 @@ async def empty_catalog():
 # during testing, which is slow
 def build_index_alias_name_for_fixture(fixture_name: str) -> str:
     return f"{settings.INDEX_NAME}-fixture-{fixture_name}"
-
-
-EU_FSF_MANIFEST = Manifest.model_validate(
-    {
-        "catalogs": [
-            {
-                "url": "https://data.opensanctions.org/datasets/latest/index.json",
-                "scope": "eu_fsf",
-                "resource_name": "entities.ftm.json",
-            }
-        ],
-        # parteispenden is included as a local dataset alongside the remote
-        # catalog so tests can exercise the "catalog + local dataset" mix.
-        "datasets": [
-            {
-                "name": "parteispenden",
-                "title": "German political party donations",
-                "path": str(
-                    FIXTURES_PATH / "dataset" / "parteispenden" / "entities.ftm.json"
-                ),
-                "version": "100",
-            }
-        ],
-    }
-)
-
-
-# This fixture is function-scoped and just points the settings to the pre-loaded fixture-specific index alias
-@pytest_asyncio.fixture(scope="function", autouse=False)
-async def live_catalog_eu_fsf(monkeypatch):
-    monkeypatch.setattr(
-        settings, "ENTITY_INDEX", build_index_alias_name_for_fixture("eu_fsf")
-    )
-    async with patch_yente_catalog(EU_FSF_MANIFEST):
-        # This call will only index the first time the fixture is used,
-        # all subsequent uses will be fast.
-        await update_index()
-        yield
 
 
 PARTEISPENDEN_MANIFEST = Manifest.model_validate(

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,8 +1,16 @@
 import pytest
 
-from .conftest import client
+from .conftest import (
+    FIXTURES_PATH,
+    build_index_alias_name_for_fixture,
+    client,
+    patch_catalog_response,
+    patch_yente_catalog,
+)
 
 from yente import settings
+from yente.data.manifest import Manifest
+from yente.search.indexer import update_index
 
 
 def test_healthz():
@@ -56,17 +64,73 @@ def test_algorithms_hidden(monkeypatch):
     assert "logic-v1" not in visible_algorithms
 
 
-@pytest.mark.usefixtures("live_catalog_eu_fsf")
-def test_catalog():
-    res = client.get("/catalog")
-    assert res.status_code == 200, res
+@pytest.mark.asyncio
+async def test_catalog(monkeypatch):
+    monkeypatch.setattr(
+        settings, "ENTITY_INDEX", build_index_alias_name_for_fixture("mocked_eu_fsf")
+    )
+    # Mocked HTTP response for the remote catalog. Includes:
+    #   - eu_fsf: scoped/loaded below, so it gets indexed and shows up as `current`.
+    #   - us_ofac_sdn: present in the catalog but NOT the loaded scope — covers
+    #     the "non-loaded dataset in catalog" case (index_current=False).
+    catalog_response = {
+        "datasets": [
+            {
+                "name": "eu_fsf",
+                "title": "EU FSF",
+                "version": "20240101000000-aaa",
+                "entities_url": (
+                    FIXTURES_PATH / "dataset" / "parteispenden" / "entities.ftm.json"
+                ).as_uri(),
+            },
+            {
+                "name": "us_ofac_sdn",
+                "title": "US OFAC SDN",
+                "version": "20240101000000-bbb",
+            },
+        ]
+    }
+    # parteispenden is declared as a local dataset alongside the (mocked) remote
+    # catalog to exercise the "catalog + local dataset" mix yente supports.
+    manifest = Manifest.model_validate(
+        {
+            "catalogs": [
+                {
+                    "url": "https://catalog.example.com/index.json",
+                    "scope": "eu_fsf",
+                }
+            ],
+            "datasets": [
+                {
+                    "name": "parteispenden",
+                    "title": "German political party donations",
+                    "path": str(
+                        FIXTURES_PATH
+                        / "dataset"
+                        / "parteispenden"
+                        / "entities.ftm.json"
+                    ),
+                    "version": "100",
+                }
+            ],
+        }
+    )
+
+    with patch_catalog_response(catalog_response):
+        async with patch_yente_catalog(manifest):
+            await update_index()
+            res = client.get("/catalog")
+
+    assert res.status_code == 200
     data = res.json()
     assert "current" in data
     assert "eu_fsf" in data["current"]
     assert "datasets" in data
     datasets = {d["name"]: d for d in data["datasets"]}
+    # us_ofac_sdn is in the catalog but not the loaded scope.
     assert datasets["us_ofac_sdn"]["index_current"] is False
     assert datasets["eu_fsf"]["index_current"] is True
+    # parteispenden is the local-dataset half of the mix.
     donations = datasets["parteispenden"]
     assert donations["load"] is True
     assert donations["index_current"] is True

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,16 @@
 import pytest
 
-from .conftest import client, assert_entity_shape
+from .conftest import (
+    ZALA_MANIFEST,
+    assert_entity_shape,
+    build_index_alias_name_for_fixture,
+    client,
+    patch_yente_catalog,
+)
+
+from yente import settings
+from yente.data.manifest import Manifest
+from yente.search.indexer import update_index
 
 
 @pytest.mark.usefixtures("zala_test_dataset")
@@ -263,13 +273,42 @@ def test_search_sorted():
         prev_seen = res["first_seen"]
 
 
-@pytest.mark.usefixtures("live_catalog_eu_fsf")
-def test_search_zakharov_scope():
-    res = client.get("/search/peps?q=alexander zakharov")
-    assert res.status_code == 200, res
-    data = res.json()
-    results = data.get("results")
-    assert len(results) == 0, results
+@pytest.mark.asyncio
+async def test_search_zakharov_scope(monkeypatch):
+    monkeypatch.setattr(
+        settings, "ENTITY_INDEX", build_index_alias_name_for_fixture("zala_zulu")
+    )
+    # Extend the ZALA manifest with a second, empty "zulu" dataset backed by
+    # /dev/null. Zakharov should be found when scoping to /search/zala but not
+    # to /search/zulu, exercising the dataset scope filter.
+    manifest = Manifest.model_validate(
+        {
+            "datasets": [
+                *(ds.copy() for ds in ZALA_MANIFEST.datasets),
+                {
+                    "name": "zulu",
+                    "title": "Empty test dataset",
+                    "entities_url": "file:///dev/null",
+                    "load": True,
+                    "version": "1",
+                },
+            ]
+        }
+    )
+
+    async with patch_yente_catalog(manifest):
+        await update_index()
+        zala_res = client.get("/search/zala?q=alexander zakharov")
+        zulu_res = client.get("/search/zulu?q=alexander zakharov")
+
+    assert zala_res.status_code == 200
+    zala_results = zala_res.json().get("results")
+    assert len(zala_results) > 0
+    assert any(r["id"] == "NK-aU5ybkbRFJucf8YMwsJvDw" for r in zala_results)
+
+    assert zulu_res.status_code == 200
+    zulu_results = zulu_res.json().get("results")
+    assert len(zulu_results) == 0
 
 
 @pytest.mark.usefixtures("zala_test_dataset")


### PR DESCRIPTION
## Summary
- `test_catalog` and `test_search_zakharov_scope` previously depended on the live OpenSanctions catalog (`live_catalog_eu_fsf`). Both are rewritten to build a minimal manifest inline — `test_catalog` with a mocked catalog HTTP response (eu_fsf + us_ofac_sdn) and `test_search_zakharov_scope` by extending `ZALA_MANIFEST` with an empty `zulu` dataset.
- The `live_catalog_eu_fsf` fixture is now unused and removed; the conftest header documents the preference for inline manifests in tests of specific behaviour.

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)