### PR TITLE
Upgrade to Elasticsearch 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
+        image: docker.elastic.co/elasticsearch/elasticsearch:9.4.2
         env:
           node.name: index
           cluster.name: yente-index

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   index:
-    # For new deployments, please use Elastic 9.x, see https://hub.docker.com/_/elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.4.2
     expose:
       - "9200"
     ports:

--- a/docs/deploy/upgrading.md
+++ b/docs/deploy/upgrading.md
@@ -36,11 +36,11 @@ At this point, your yente is running entirely from the `yente-blue` indices. You
 
 ## Upgrading from Elasticsearch 8 to 9
 
-Elasticsearch is the search index software underlying yente. Version 9 of Elasticsearch was released in April 2025, and version 8 will be end-of-life in January 2027. Versions of yente released in 2025 or later are already compatible with both version 8 and 9 of the Elastic server, but versions of yente released after May 2026 will only be compatible with Elastic server 9. See the [official documentation for more information](https://www.elastic.co/docs/reference/elasticsearch/clients/python#_compatibility).
+Elasticsearch is the search index software underlying yente. Version 9 of Elasticsearch was released in April 2025, and version 8 will be end-of-life in January 2027. yente 5.4 and earlier are compatible with both Elastic server 8 and 9; yente 5.5 and later only support Elastic server 9. See the [official documentation for more information](https://www.elastic.co/docs/reference/elasticsearch/clients/python#_compatibility).
 
-When **upgrading from Elasticsearch 8 to 9** in the single-node setup that is used by default in the docker-compose based deployment outlined in [our documentation on deploying yente](index.md), we have observed no issues using the following path:
+If you are still on Elastic server 8, you need to upgrade your Elasticsearch cluster to 9 before upgrading yente. In the single-node setup that is used by default in the docker-compose based deployment outlined in [our documentation on deploying yente](index.md), we have observed no issues using the following path:
 
-1. Upgrade Elasticsearch to the latest version in the 8.x series in `docker-compose.yml` (at the time of writing, that's `8.19.13`, check [Docker Hub](https://hub.docker.com/_/elasticsearch) for the latest)
+1. Upgrade Elasticsearch to the latest version in the 8.x series (at the time of writing, that's `8.19.16`, check [Docker Hub](https://hub.docker.com/_/elasticsearch) for the latest)
 2. Restart Elasticsearch and verify everything works as expected (`docker compose up -d index`)
 3. Upgrade Elasticsearch to the latest version in the 9.x series in `docker-compose.yml`
 4. Restart Elasticsearch and verify everything works as expected.

--- a/kubernetes.example.yml
+++ b/kubernetes.example.yml
@@ -213,7 +213,7 @@ kind: Elasticsearch
 metadata:
   name: yente-index
 spec:
-  version: 8.14.3
+  version: 9.4.2
   http:
     tls:
       selfSignedCertificate:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "OpenSanctions", email = "info@opensanctions.org" }]
 license = { file = "LICENSE" }
 readme = "README.md"
 dependencies = [
-    "elasticsearch[async] == 8.19.3",
+    "elasticsearch[async] == 9.4.1",
     "opensearch-py[async] == 3.2.0",
     "uvicorn[standard] == 0.49.0",
     "httpx[http2] == 0.28.1",

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -36,8 +36,8 @@ async def test_search_provider_creates_spans(search_provider, span_exporter):
     assert len(spans) == 1, f"Expected 1 search span, got: {[s.name for s in spans]}"
 
     span = spans[0]
-    assert span.attributes["db.system"] in ("elasticsearch", "opensearch")
-    assert span.attributes["db.operation"] == "search"
+    assert span.attributes["db.system.name"] in ("elasticsearch", "opensearch")
+    assert span.attributes["db.operation.name"] == "search"
 
 
 @pytest.mark.asyncio

--- a/yente/provider/elastic.py
+++ b/yente/provider/elastic.py
@@ -28,8 +28,8 @@ class ElasticSearchProvider(SearchProvider):
         )
         if settings.INDEX_SNIFF:
             kwargs["sniff_on_start"] = True
-            kwargs["sniffer_timeout"] = 60
-            kwargs["sniff_on_connection_fail"] = True
+            kwargs["min_delay_between_sniffing"] = 60
+            kwargs["sniff_on_node_failure"] = True
         if settings.ES_CLOUD_ID:
             log.info("Connecting to Elastic Cloud ID", cloud_id=settings.ES_CLOUD_ID)
             kwargs["cloud_id"] = settings.ES_CLOUD_ID
@@ -122,9 +122,7 @@ class ElasticSearchProvider(SearchProvider):
                 await self.client().indices.clone(
                     index=base_version,
                     target=target_version,
-                    body={
-                        "settings": {"index": {"blocks": {"read_only": False}}},
-                    },
+                    settings={"index": {"blocks": {"read_only": False}}},
                 )
             except Exception:
                 # On failure, clean up our failed clone and re-raise
@@ -170,9 +168,7 @@ class ElasticSearchProvider(SearchProvider):
 
     async def set_index_metadata(self, index: str, metadata: Dict[str, Any]) -> None:
         try:
-            await self.client().indices.put_mapping(
-                index=index, body={"_meta": metadata}
-            )
+            await self.client().indices.put_mapping(index=index, meta=metadata)
         except (ApiError, TransportError) as te:
             raise YenteIndexError(f"Could not set index metadata: {te}") from te
 

--- a/yente/provider/opensearch.py
+++ b/yente/provider/opensearch.py
@@ -41,8 +41,8 @@ def traced(method: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(method)
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         span = trace.get_current_span()
-        span.set_attribute("db.system", "opensearch")
-        span.set_attribute("db.operation", name)
+        span.set_attribute("db.system.name", "opensearch")
+        span.set_attribute("db.operation.name", name)
         return await method(self, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Summary
- yente 5.4 was the last yente release compatible with Elastic server 8 — see #823. elasticsearch-py 9 won't talk to ES 8 servers, so users need to upgrade their Elasticsearch cluster to 9 before upgrading yente.
- Bumps `elasticsearch[async]` 8.19.3 → 9.4.1 and the default ES image (docker-compose, `kubernetes.example.yml`, CI) to 9.4.2.
- Renames the sniffing kwargs in `ElasticSearchProvider`: `sniffer_timeout` → `min_delay_between_sniffing`, `sniff_on_connection_fail` → `sniff_on_node_failure` ([renamed in 9.0](https://www.elastic.co/docs/release-notes/elasticsearch/clients/python/breaking-changes#remove-deprecated-elasticsearch-options)).
- Aligns the OpenSearch provider OTEL span attributes with the new semantic conventions `db.system.name` / `db.operation.name` that elasticsearch-py 9.1 already emits — see [PR #2999](https://github.com/elastic/elasticsearch-py/pull/2999) / [9.1.0 release notes](https://www.elastic.co/docs/release-notes/elasticsearch/clients/python#910-2025-07-30) — so both backends look the same in tracing.
- Drive-by: switches `indices.clone` / `put_mapping` from `body=` to the named `settings=` / `meta=` params; `body=` has been [deprecated since 8.0](https://www.elastic.co/guide/en/elasticsearch/client/python-api/8.0/release-notes.html) and fires a DeprecationWarning at runtime in 9.x.
- Updates the "Upgrading from Elasticsearch 8 to 9" docs to reflect that ES 9 is now the only supported server version going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)