### PR TITLE
Point default manifests at index.json instead of default/catalog.json

### DIFF
--- a/manifests/civic.yml
+++ b/manifests/civic.yml
@@ -1,5 +1,5 @@
 catalogs:
-  - url: "https://data.opensanctions.org/datasets/latest/default/catalog.json"
+  - url: "https://data.opensanctions.org/datasets/latest/index.json"
     scope: default
     resource_name: entities.ftm.json
 

--- a/manifests/commercial.yml
+++ b/manifests/commercial.yml
@@ -1,5 +1,5 @@
 catalogs:
-  - url: "https://delivery.opensanctions.com/datasets/latest/default/catalog.json"
+  - url: "https://delivery.opensanctions.com/datasets/latest/index.json"
     auth_token: "$OPENSANCTIONS_DELIVERY_TOKEN"
     scope: default
     resource_name: entities.ftm.json


### PR DESCRIPTION
While testing yente's checksum checking, I noticed the catalog URL we ship in the default manifest is `https://delivery.opensanctions.com/datasets/latest/default/catalog.json`.

The problem: `default/catalog.json` only gets rewritten when the `default` collection is exported, so catalog freshness (versions/checksums) is gated on the export cadence.

`datasets/latest/index.json` is the master catalog regenerated by the metadata index job every 20 min. With `scope: default` it gives the same dataset list but fresher version/checksum metadata — which is exactly what the checksum check relies on. The knowledgebase's own custom-manifest example already recommends this form.

Changed both shipped manifests:
- `commercial.yml` (the default, `MANIFEST_DEFAULT_PATH`) → delivery host
- `civic.yml` → public host, same fix for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)