### PR TITLE
Remove name_variants index field

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -215,26 +215,37 @@ def test_id_pass_through():
 
 @pytest.mark.usefixtures("zala_test_dataset")
 def test_match_name_without_spaces():
-    # A name query with spaces omitted is a single token to the query
-    # analyzer, so ES fuzziness can't bridge the gap to the separate indexed tokens. We
-    # solve this at index time by also indexing compound tokens for adjacent name parts,
-    # and this test verifies that.
-    # The test also shows a limitation of our approach: the zala dataset only contains
-    # the full name "Alexander Vyacheslavovich Zakharov", so we can't match "alexanderzakharov"
-    # (for now)
+    # A name with spaces omitted ("alexandervyacheslavovichzakharov") is a single token to
+    # the query analyzer, so the per-token names match can't bridge the gap to the
+    # separate indexed tokens. We solve this with the character n-gram sub-field on the
+    # names field, which lets the space-less token still match the indexed name via shared
+    # n-grams, and this test verifies that.
+    #
+    # The bogus "foo bar" name is just there to keep the query from being treated as a
+    # single-word ("short") query, for which we always fall back to n-gram matching
+    # regardless of the fuzzy setting. That way we can show the n-gram path is what makes
+    # the space-less match work, by checking it disappears when fuzzy matching is off.
     query = {
         "queries": {
             "a": {
                 "schema": "Person",
-                "properties": {"name": ["alexandervyacheslavovichzakharov"]},
+                "properties": {"name": ["alexandervyacheslavovichzakharov", "foo bar"]},
             }
         }
     }
-    resp = client.post("/match/zala", json=query)
-    assert resp.status_code == 200, resp.text
-    res = resp.json()["responses"]["a"]
-    assert len(res["results"]) > 0
-    assert res["results"][0]["id"] == "NK-aU5ybkbRFJucf8YMwsJvDw"
+
+    with mock.patch("yente.settings.MATCH_FUZZY", False):
+        resp = client.post("/match/zala", json=query)
+        assert resp.status_code == 200, resp.text
+        res = resp.json()["responses"]["a"]
+        assert len(res["results"]) == 0
+
+    with mock.patch("yente.settings.MATCH_FUZZY", True):
+        resp = client.post("/match/zala", json=query)
+        assert resp.status_code == 200, resp.text
+        res = resp.json()["responses"]["a"]
+        assert len(res["results"]) > 0
+        assert res["results"][0]["id"] == "NK-aU5ybkbRFJucf8YMwsJvDw"
 
 
 @pytest.mark.usefixtures("zala_test_dataset")

--- a/yente/search/indexer.py
+++ b/yente/search/indexer.py
@@ -4,7 +4,6 @@ from typing import Any, AsyncGenerator, AsyncIterable, Dict, List, Optional, Set
 from followthemoney import registry
 from followthemoney.exc import FollowTheMoneyException
 from followthemoney.names import entity_names
-from rigour.names import Name
 
 from yente import settings
 from yente.data.manifest import Catalog
@@ -27,7 +26,6 @@ from yente.search.mapping import (
     NAME_PART_FIELD,
     NAME_PHONETIC_FIELD,
     NAME_SYMBOLS_FIELD,
-    NAME_VARIANTS_FIELD,
     make_entity_mapping,
     INDEX_SETTINGS,
 )
@@ -101,12 +99,6 @@ async def iter_entity_docs(
     )
 
 
-def build_name_variants(name: Name) -> Set[str]:
-    # "vladimir putin" -> "valdimirputin"
-    # Normal Elastic fuzzy matching doesn't catch this because fuzzyness is per-token
-    return set(["".join([p.comparable for p in name.parts])])
-
-
 def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     doc = entity.to_dict(matchable=True)
     entity_id = doc.pop("id")
@@ -119,10 +111,7 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     name_parts: Set[str] = set()
     name_phonemes: Set[str] = set()
     name_symbols: Set[str] = set()
-    name_variants: Set[str] = set()
     for name in entity_names(entity, infer_initials=False):
-        name_variants.update(build_name_variants(name))
-
         name_symbols.update(index_symbols(name.symbols))
         for part in name.parts:
             name_parts.add(part.comparable)
@@ -136,7 +125,6 @@ def build_indexable_entity_doc(entity: Entity) -> Dict[str, Any]:
     doc[NAME_PART_FIELD] = list(name_parts)
     doc[NAME_PHONETIC_FIELD] = list(name_phonemes)
     doc[NAME_SYMBOLS_FIELD] = list(name_symbols)
-    doc[NAME_VARIANTS_FIELD] = list(name_variants)
     if registry.date.group is not None:
         doc[registry.date.group] = expand_dates(doc.pop(registry.date.group, []))
     doc["text"] = entity.pop("indexText")

--- a/yente/search/mapping.py
+++ b/yente/search/mapping.py
@@ -73,7 +73,6 @@ NAME_NGRAMS_FIELD = f"{NAMES_FIELD}.ngrams"
 NAME_PART_FIELD = "name_parts"
 NAME_SYMBOLS_FIELD = "name_symbols"
 NAME_PHONETIC_FIELD = "name_phonetic"
-NAME_VARIANTS_FIELD = "name_variants"
 
 
 def make_field(
@@ -170,7 +169,6 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
         "entity_values_count": make_field("integer"),
         NAME_PHONETIC_FIELD: make_keyword(),
         NAME_PART_FIELD: make_field("keyword", copy_to=["text"]),
-        NAME_VARIANTS_FIELD: make_field("keyword"),
         NAME_SYMBOLS_FIELD: make_field("keyword"),
         "last_change": make_field("date", format=DATE_FORMAT),
         "last_seen": make_field("date", format=DATE_FORMAT),
@@ -203,7 +201,6 @@ def make_entity_mapping(schemata: Optional[Iterable[Schema]] = None) -> Dict[str
     drop_fields.append("text")
     drop_fields.append(NAME_PHONETIC_FIELD)
     drop_fields.append(NAME_PART_FIELD)
-    drop_fields.append(NAME_VARIANTS_FIELD)
     drop_fields.append(NAME_SYMBOLS_FIELD)
     drop_fields.remove(NAMES_FIELD)
     return {

--- a/yente/search/queries.py
+++ b/yente/search/queries.py
@@ -1,5 +1,4 @@
 import enum
-import itertools
 from pprint import pprint  # noqa
 from rigour.names import Name, NamePart, Symbol, representative_names
 from collections import defaultdict
@@ -15,8 +14,7 @@ from yente import settings
 from yente.logs import get_logger
 from yente.data.dataset import Dataset
 from yente.data.util import entity_weak_names, index_symbols
-from yente.search.indexer import build_name_variants
-from yente.search.mapping import NAME_SYMBOLS_FIELD, NAME_VARIANTS_FIELD, NAMES_FIELD
+from yente.search.mapping import NAME_SYMBOLS_FIELD, NAMES_FIELD
 from yente.search.mapping import NAME_PART_FIELD, NAME_PHONETIC_FIELD, NAME_NGRAMS_FIELD
 
 log = get_logger(__name__)
@@ -166,16 +164,6 @@ def names_query(entity: EntityProxy) -> List[Clause]:
 
     seen: Set[str] = set()
     consolidated_names = Name.consolidate_names(name_objs)
-
-    # Name variants are keyword renditions of common name variations that people expect to
-    # match but that the ES fuzzyness does not catch.
-    # Example: "vladimirputin" (without a space) does not get matched by the per-token fuzzyness
-    name_variants = set(
-        itertools.chain.from_iterable(
-            build_name_variants(name) for name in consolidated_names
-        )
-    )
-    shoulds.append(tqs(NAME_VARIANTS_FIELD, name_variants, boost=2))
 
     for name in consolidated_names:
         part_symbols: Dict[NamePart, Set[Symbol]] = defaultdict(set)

--- a/yente/settings.py
+++ b/yente/settings.py
@@ -209,7 +209,7 @@ ENTITY_INDEX = f"{INDEX_NAME}-entities"
 # Bump this when the index format changes and a full reindex is required.
 # Be careful to make the query code compatible with the old index format, otherwise
 # yente will be unable to serve requests after the upgrade until the first reindex completes.
-INDEX_VERSION = "017"
+INDEX_VERSION = "018"
 # Bump this evn var when you want to trigger a full reindex.
 INDEX_REBUILD_ID = env_str("YENTE_INDEX_REBUILD_ID", "a")
 


### PR DESCRIPTION
The `name_variants` field stored space-joined renditions of names (e.g. `vladimirputin`) to catch space-less queries that per-token ES fuzziness misses. Now that the n-gram sub-field on the names field landed in https://github.com/opensanctions/yente/pull/1176, this is redundant — the n-grams cover the same case — so I've ripped out the field and its query clause.

Changes:
- Drop `name_variants` from the indexer, query builder, and mapping (field + drop-list).
- Bump `INDEX_VERSION` `017` → `018` since the index format changed (full reindex required).
- Rework `test_match_name_without_spaces` to exercise the n-gram path instead of `name_variants`, and assert both directions: with `MATCH_FUZZY=False` the space-less name no longer matches, with it on it does.

On the test: the natural fully-joined query (`alexandervyacheslavovichzakharov`) is a single token, which trips `is_short` and forces n-grams on regardless of the fuzzy setting, so it can't show the fuzzy=False failure. I add a bogus `foo bar` name to the query so it's not treated as "short", which lets the test actually isolate the n-gram path. A bit awkward, but it's the cleanest way to demonstrate the dependency without touching `is_short`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)