### PR TITLE
Serve an ETag on GET /catalog to enable conditional requests

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,11 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from .conftest import (
     FIXTURES_PATH,
+    app,
     build_index_alias_name_for_fixture,
     client,
     patch_catalog_response,
@@ -10,6 +14,8 @@ from .conftest import (
 
 from yente import settings
 from yente.data.manifest import Manifest
+from yente.provider import get_provider
+from yente.routers.admin import catalog_etag, if_none_match
 from yente.search.indexer import update_index
 
 
@@ -136,6 +142,77 @@ async def test_catalog(monkeypatch):
     assert donations["index_current"] is True
     assert donations["index_version"] == "100"
     assert donations["version"] == "100"
+
+
+@pytest.mark.asyncio
+async def test_catalog_etag():
+    manifest = Manifest.model_validate(
+        {
+            "datasets": [
+                {
+                    "name": "parteispenden",
+                    "title": "German political party donations",
+                    "path": str(
+                        FIXTURES_PATH / "dataset" / "parteispenden" / "entities.ftm.json"
+                    ),
+                    "version": "100",
+                    "load": True,
+                }
+            ]
+        }
+    )
+    # /catalog only asks the provider for aliased index names, so a stub keeps
+    # this test free of a live Elasticsearch.
+    provider = AsyncMock()
+    provider.get_alias_indices.return_value = []
+    app.dependency_overrides[get_provider] = lambda: provider
+    try:
+        async with patch_yente_catalog(manifest):
+            res = client.get("/catalog")
+            assert res.status_code == 200, res.text
+            etag = res.headers.get("etag")
+            assert etag is not None
+            assert res.headers.get("cache-control") == "public, max-age=60"
+
+            # A matching validator yields a bodiless 304 that still carries it.
+            not_modified = client.get("/catalog", headers={"If-None-Match": etag})
+            assert not_modified.status_code == 304, not_modified.text
+            assert not_modified.headers.get("etag") == etag
+            assert not_modified.content == b""
+
+            # A stale validator still returns the full body.
+            stale = client.get("/catalog", headers={"If-None-Match": '"stale"'})
+            assert stale.status_code == 200
+            assert stale.headers.get("etag") == etag
+
+            # The wildcard matches the current representation.
+            wildcard = client.get("/catalog", headers={"If-None-Match": "*"})
+            assert wildcard.status_code == 304
+    finally:
+        app.dependency_overrides.pop(get_provider, None)
+
+
+def test_catalog_etag_helpers():
+    def _catalog(triples):
+        return SimpleNamespace(
+            datasets=[
+                SimpleNamespace(
+                    name=n, model=SimpleNamespace(version=v, index_version=iv)
+                )
+                for (n, v, iv) in triples
+            ]
+        )
+
+    etag = catalog_etag(_catalog([("x", "1", None), ("y", "2", "2")]))
+    # Order-independent, quoted (strong), and sensitive to version changes.
+    assert etag == catalog_etag(_catalog([("y", "2", "2"), ("x", "1", None)]))
+    assert etag != catalog_etag(_catalog([("x", "1", None), ("y", "3", "3")]))
+    assert etag[0] == '"' and etag[-1] == '"'
+    assert if_none_match(None, etag) is False
+    assert if_none_match(etag, etag) is True
+    assert if_none_match('"other", %s' % etag, etag) is True
+    assert if_none_match("*", etag) is True
+    assert if_none_match('"other"', etag) is False
 
 
 def test_updatez_get():

--- a/yente/routers/admin.py
+++ b/yente/routers/admin.py
@@ -1,5 +1,6 @@
-from typing import List
-from fastapi import APIRouter, Depends, Query
+import hashlib
+from typing import Any, List, Optional
+from fastapi import APIRouter, Depends, Query, Request, Response, status
 from fastapi import HTTPException
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import FileResponse, HTMLResponse
@@ -10,6 +11,7 @@ from yente.logs import get_logger
 from yente.data import get_catalog
 from yente.data.common import ErrorResponse, StatusResponse
 from yente.data.common import DataCatalogModel, AlgorithmResponse, Algorithm
+from yente.data.manifest import Catalog
 from yente.provider import SearchProvider, get_provider
 from yente.routers.util import ENABLED_ALGORITHMS
 from yente.search.indexer import update_index, update_index_threaded
@@ -17,6 +19,37 @@ from yente.search.status import sync_dataset_versions
 
 log = get_logger(__name__)
 router = APIRouter()
+
+# The /catalog response is fully determined by the loaded datasets and their
+# versions, which only change when data is (re-)indexed (every few hours at
+# most). Allow clients and intermediary caches to revalidate cheaply.
+CATALOG_CACHE_CONTROL = "public, max-age=60"
+
+
+def catalog_etag(catalog: Catalog) -> str:
+    """Return a strong ETag for the catalog response.
+
+    The response body is fully determined by each dataset's name, version and
+    currently-indexed version, so a hash over those triples changes exactly
+    when the response would. This avoids serialising the body just to compare.
+    """
+    parts = [
+        "%s:%s:%s" % (ds.name, ds.model.version, ds.model.index_version)
+        for ds in catalog.datasets
+    ]
+    digest = hashlib.sha1("\n".join(sorted(parts)).encode("utf-8")).hexdigest()
+    return '"%s"' % digest
+
+
+def if_none_match(header: Optional[str], etag: str) -> bool:
+    """Check whether an ``If-None-Match`` header matches the given ETag.
+
+    Supports the ``*`` wildcard and a comma-separated list of ETags.
+    """
+    if header is None:
+        return False
+    candidates = [tag.strip() for tag in header.split(",")]
+    return "*" in candidates or etag in candidates
 
 
 @router.get(
@@ -95,6 +128,7 @@ async def readyz(
     summary="Data catalog",
     tags=["Data access"],
     response_model=DataCatalogModel,
+    responses={304: {"description": "The catalog has not changed."}},
 )
 @router.get(
     "/manifest",
@@ -102,15 +136,26 @@ async def readyz(
     include_in_schema=False,
 )
 async def catalog(
+    request: Request,
+    response: Response,
     provider: SearchProvider = Depends(get_provider),
-) -> DataCatalogModel:
+) -> Any:
     """Return the service manifest, which includes a list of all indexed datasets.
 
     The manifest is the configuration file of the yente service. It specifies what
     data sources are included, and how often they should be loaded.
+
+    The response carries an `ETag` derived from the loaded dataset versions;
+    clients can send it back in an `If-None-Match` header to revalidate and
+    receive a bodiless `304 Not Modified` when nothing has changed.
     """
     catalog = await get_catalog()
     await sync_dataset_versions(provider, catalog)
+    etag = catalog_etag(catalog)
+    headers = {"ETag": etag, "Cache-Control": CATALOG_CACHE_CONTROL}
+    if if_none_match(request.headers.get("if-none-match"), etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
     model = DataCatalogModel(datasets=[], current=[], outdated=[])
     for dataset in catalog.datasets:
         if dataset.model.load and dataset.model.index_current:


### PR DESCRIPTION
Closes #1202.

### What

`GET /catalog` (and the `/manifest` alias) now emit a strong `ETag` and honour `If-None-Match` with a bodiless `304 Not Modified`, so long-lived pollers (e.g. `yente-client`) can revalidate cheaply instead of refetching an unchanged body on every TTL tick.

### How

- The response is fully determined by the loaded datasets' `(name, version, index_version)` triples, so the validator is a SHA-1 over those (sorted, so it's order-independent) — computed after `sync_dataset_versions`, without serialising the body to compare. It changes exactly when the response would.
- `If-None-Match` is matched against the ETag with support for the `*` wildcard and a comma-separated list; on a match the handler returns an empty `304` that still carries the `ETag`.
- A short `Cache-Control: public, max-age=60` is added as the issue suggested, so intermediary caches get a hint while still revalidating well within the "every few hours" version-bump cadence.

Kept to `yente/routers/admin.py`; the ETag/If-None-Match logic is factored into two small pure helpers (`catalog_etag`, `if_none_match`).

### Tests

Added to `tests/test_base.py`:
- `test_catalog_etag` — drives the endpoint through `TestClient`, asserting: `200` carries an `ETag` + `Cache-Control`; a matching `If-None-Match` returns a bodiless `304` with the validator; a stale validator returns the full body; `*` matches. It stubs the search provider (the endpoint only asks it for aliased index names via `sync_dataset_versions`), so it needs no live Elasticsearch, following the existing `test_catalog` pattern.
- `test_catalog_etag_helpers` — unit-covers the hash (order-independence, sensitivity to version / index_version changes, strong-validator quoting) and the `If-None-Match` matching (list + `*` + miss).

Happy to adjust the `max-age`, drop the `Cache-Control`, or move the helpers if you'd prefer them elsewhere.
