### PR TITLE
Use a fixed date for the OpenAPI timestamp examples

### DIFF
--- a/yente/data/common.py
+++ b/yente/data/common.py
@@ -9,7 +9,6 @@ from nomenklatura.matching.types import (
 )
 from pydantic import BaseModel, Field, field_serializer
 
-from yente import settings
 from yente.data.dataset import YenteDatasetModel
 from yente.data.entity import Entity
 
@@ -28,9 +27,11 @@ class EntityResponse(BaseModel):
     datasets: list[str] = Field([], examples=[["us_ofac_sdn"]])
     referents: list[str] = Field([], examples=[["ofac-1234"]])
     target: bool = Field(False)
-    first_seen: datetime | None = Field(None, examples=[settings.RUN_DT])
-    last_seen: datetime | None = Field(None, examples=[settings.RUN_DT])
-    last_change: datetime | None = Field(None, examples=[settings.RUN_DT])
+    first_seen: datetime | None = Field(None, examples=[datetime(2026, 1, 1, 12, 0, 0)])
+    last_seen: datetime | None = Field(None, examples=[datetime(2026, 1, 1, 12, 0, 0)])
+    last_change: datetime | None = Field(
+        None, examples=[datetime(2026, 1, 1, 12, 0, 0)]
+    )
 
     # Entities come out of ES with these already as ISO strings. Responses
     # are built via model_construct to skip re-validation, so pydantic has


### PR DESCRIPTION
The OpenAPI examples for `first_seen`, `last_seen` and `last_change` came from `settings.RUN_DT`, which is stamped at import time. Every process published a different schema, so it could not be diffed between builds. This came up while checking that https://github.com/opensanctions/yente/pull/1233 left the schema alone.

The date is now fixed and inline. It is also naive, which is the format these fields actually emit on the wire — the aware `RUN_DT` rendered as `2026-08-10T10:26:19.335915Z`, with a `Z` and microseconds that no response ever carries.

`settings.RUN_DT` stays: it is still the `last_export` fallback in `yente/data/dataset.py`.

Checked by dumping `app.openapi()` from two processes: identical now, and the only change against main is those three example values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
