### PR TITLE
Stop showing a batch as the /match request example

### DIFF
--- a/examples/match_api.py
+++ b/examples/match_api.py
@@ -26,9 +26,9 @@ EXAMPLE_2 = {
     },
 }
 
-# We put both of these queries into a matching batch, giving each of them an
-# ID that we can recognize it by later:
-BATCH = {"queries": {"q1": EXAMPLE_1, "q2": EXAMPLE_2}}
+# We give each of these queries an ID that we can recognize it by later:
+QUERY_1 = {"queries": {"q1": EXAMPLE_1}}
+QUERY_2 = {"queries": {"q2": EXAMPLE_2}}
 
 # Configure an API key for the service. This is required for the hosted API.
 headers = {"Authorization": f"Apikey {API_KEY}"}
@@ -37,16 +37,18 @@ headers = {"Authorization": f"Apikey {API_KEY}"}
 # of entities and can be turned off for a performance boost.
 params = {"algorithm": "best", "fuzzy": "false"}
 
-# Send the batch off to the API and raise an exception for a non-OK response code.
-response = requests.post(URL, json=BATCH, headers=headers, params=params)
-response.raise_for_status()
-
-responses = response.json().get("responses")
+# Send each query in its own request and raise an exception for a non-OK response
+# code. More than one query can go in a single request, but sending them separately
+# lets them be spread across instances.
+response_1 = requests.post(URL, json=QUERY_1, headers=headers, params=params)
+response_1.raise_for_status()
+response_2 = requests.post(URL, json=QUERY_2, headers=headers, params=params)
+response_2.raise_for_status()
 
 # The responses will include a set of results for each entity, and a parsed version of
 # the original query:
-example_1_response = responses.get("q1")
-example_2_response = responses.get("q2")
+example_1_response = response_1.json().get("responses").get("q1")
+example_2_response = response_2.json().get("responses").get("q2")
 
 # You can use the returned query to debug if the API correctly parsed and interpreted
 # the queries you provided. If any of the fields or values are missing, it's an

--- a/yente/routers/match.py
+++ b/yente/routers/match.py
@@ -192,14 +192,14 @@ async def match(
     ] = (),
 ) -> EntityMatchResponse:
     """Match entities based on a complex set of criteria, like name, date of birth
-    and nationality of a person. This works by submitting a batch of entities, each
-    formatted like those returned by the API.
+    and nationality of a person. This works by submitting an entity formatted like
+    those returned by the API.
 
     Tutorials:
     * [Using the matching API](https://www.opensanctions.org/docs/api/matching/)
     * [Configuring the scoring system](https://www.opensanctions.org/docs/api/scoring/)
 
-    For example, the following would be valid query examples:
+    For example, the following would be a valid query:
 
     ```json
     "queries": {
@@ -210,33 +210,25 @@ async def match(
                 "birthDate": ["1975-04-21"],
                 "nationality": ["us"]
             }
-        },
-        "entity2": {
-            "schema": "Company",
-            "properties": {
-                "name": ["Brilliant Amazing Limited"],
-                "jurisdiction": ["hk"],
-                "registrationNumber": ["84BA99810"]
-            }
         }
     }
     ```
-    The values for `entity1`, `entity2` can be chosen freely to correlate results
-    on the client side when the request is returned. The responses will be given
-    for each submitted example like this:
+    The value for `entity1` can be chosen freely to correlate the result on the
+    client side when the request is returned. The response will be given for the
+    submitted example like this:
 
     ```json
     "responses": {
         "entity1": {
             "query": {},
             "results": [...]
-        },
-        "entity2": {
-            "query": {},
-            "results": [...]
         }
     }
     ```
+
+    More than one query can be submitted in a single request, but we recommend
+    sending one query per request: each request runs on a single CPU core, so
+    separate requests can be spread across instances.
 
     The precision of the results will be dependent on the amount of detail submitted
     with each example. The following properties are most helpful for particular types:


### PR DESCRIPTION
Related to #1001.

[`docs/deploy/scaling.md`](https://github.com/opensanctions/yente/blob/d68b2af170da4b446cfe0e5f17ff33a61848b055/docs/deploy/scaling.md#L37) says not to batch queries into one request, but the `/match` API reference still shows a two-entity batch as its example. This reduces the example to a single query and adds a note that more than one query is still accepted but not recommended. The API itself is unchanged.

`examples/match_api.py` is changed in a separate commit, in case you'd rather leave `examples/` alone.