### PR TITLE
Test deep nesting through a Family edge

### DIFF
--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -50,6 +50,7 @@ def test_entity_nested_family():
 
     families = props["familyRelative"]
     assert len(families) == 4
+    assert isinstance(families[0], dict)
     fam = by_id(families, "ofac-6d023267c742427bc92220ad97daca2e17b136ff")
     assert fam["schema"] == "Family"
     assert fam["properties"]["relationship"] == ["Family member of"]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -39,6 +39,35 @@ def test_entity_fetch():
     assert sanc["schema"] == "Sanction"
 
 
+@pytest.mark.usefixtures("zala_test_dataset")
+def test_entity_nested_family():
+    """Deep nesting across a Family edge: the root person, the Family entities
+    naming them as a relative, and the person on the other side of each."""
+    res = client.get("/entities/NK-aU5ybkbRFJucf8YMwsJvDw")
+    assert res.status_code == 200
+    data = res.json()
+    props = data["properties"]
+
+    families = props["familyRelative"]
+    assert len(families) == 4
+    fam = by_id(families, "ofac-6d023267c742427bc92220ad97daca2e17b136ff")
+    assert fam["schema"] == "Family"
+    assert fam["properties"]["relationship"] == ["Family member of"]
+    # The interstitial still refers to the root, but doesn't nest it.
+    assert fam["properties"]["relative"] == ["NK-aU5ybkbRFJucf8YMwsJvDw"]
+
+    assert len(fam["properties"]["person"]) == 1
+    relative = fam["properties"]["person"][0]
+    assert relative["schema"] == "Person"
+    assert relative["caption"] == "Nikita Aleksandrovich Zakharov"
+    assert_entity_shape(relative)
+
+    # No path leads back to the root.
+    for fam in families:
+        for person in fam["properties"]["person"]:
+            assert person["id"] != data["id"]
+
+
 @pytest.mark.usefixtures("parteispenden_test_dataset")
 def test_entity_not_nested():
     res = client.get("/entities/281d01c426ce39ddf80aa0e46574843c1ba8bfc9?nested=false")

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -44,7 +44,7 @@ def test_entity_nested_family():
     """Deep nesting across a Family edge: the root person, the Family entities
     naming them as a relative, and the person on the other side of each."""
     res = client.get("/entities/NK-aU5ybkbRFJucf8YMwsJvDw")
-    assert res.status_code == 200
+    assert res.status_code == 200, res.text
     data = res.json()
     props = data["properties"]
 


### PR DESCRIPTION
Closes #80.

Adds a test that walks the nested response across a `Family` edge: the root person, the four `Family` entities naming them as a relative, and the person on the other side of each. The `zala` fixture already has these ties, so no fixture changes.

The general case has been covered since #686. `test_entity_nested` now walks `Person → Payment → Organization` on `parteispenden`. What was missing is the `Family` case this issue names, and `zala` is the only fixture with it.

The `, res.text` on the status assertion is a separate commit. Most assertions under `tests/` attach a message but this file mostly doesn't, so drop it if you'd rather keep the file consistent.
